### PR TITLE
스프린트1 구현

### DIFF
--- a/src/main/java/apptive/team5/Team5Application.java
+++ b/src/main/java/apptive/team5/Team5Application.java
@@ -3,11 +3,15 @@ package apptive.team5;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class Team5Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/apptive/team5/Team5Application.java
+++ b/src/main/java/apptive/team5/Team5Application.java
@@ -8,10 +8,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
-@EnableJpaAuditing
-@EnableScheduling
 @SpringBootApplication
-@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class Team5Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/apptive/team5/config/DefaultImageConfig.java
+++ b/src/main/java/apptive/team5/config/DefaultImageConfig.java
@@ -1,0 +1,23 @@
+package apptive.team5.config;
+
+import apptive.team5.global.DefaultImageProperties;
+import apptive.team5.user.domain.UserEntity;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({
+        DefaultImageProperties.class
+})
+@RequiredArgsConstructor
+public class DefaultImageConfig {
+
+    private final DefaultImageProperties defaultImageProperties;
+
+    @PostConstruct
+    public void init() {
+        UserEntity.setDefaultImage(defaultImageProperties.getProfile());
+    }
+}

--- a/src/main/java/apptive/team5/config/JpaConfig.java
+++ b/src/main/java/apptive/team5/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package apptive.team5.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/apptive/team5/config/SchedulerConfig.java
+++ b/src/main/java/apptive/team5/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package apptive.team5.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/apptive/team5/config/WebConfig.java
+++ b/src/main/java/apptive/team5/config/WebConfig.java
@@ -1,0 +1,11 @@
+package apptive.team5.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class WebConfig {
+}

--- a/src/main/java/apptive/team5/diary/controller/DiaryController.java
+++ b/src/main/java/apptive/team5/diary/controller/DiaryController.java
@@ -24,7 +24,8 @@ public class DiaryController {
     @GetMapping("/my")
     public ResponseEntity<Page<DiaryResponse>> getMyMusicDiary(
             @AuthenticationPrincipal String identifier,
-            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "5") int size) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size) {
 
 
         Page<DiaryResponse> response = diaryService.getMyDiaries(identifier, PageRequest.of(page, size));

--- a/src/main/java/apptive/team5/diary/controller/DiaryController.java
+++ b/src/main/java/apptive/team5/diary/controller/DiaryController.java
@@ -1,0 +1,34 @@
+package apptive.team5.diary.controller;
+
+import apptive.team5.diary.dto.DiaryResponse;
+import apptive.team5.diary.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.connector.Response;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/diaries/")
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @GetMapping("/my")
+    public ResponseEntity<Page<DiaryResponse>> getMyMusicDiary(
+            @AuthenticationPrincipal String identifier,
+            @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "5") int size) {
+
+
+        Page<DiaryResponse> response = diaryService.getMyDiaries(identifier, PageRequest.of(page, size));
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
@@ -1,0 +1,8 @@
+package apptive.team5.diary.dto;
+
+
+public record DiaryResponse(
+        String content,
+        String videoUrl
+) {
+}

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -1,0 +1,55 @@
+package apptive.team5.diary.service;
+
+import apptive.team5.diary.dto.DiaryResponse;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final UserLowService userLowService;
+
+    public Page<DiaryResponse> getMyDiaries(String identifier, Pageable pageable) {
+
+        UserEntity findUser = userLowService.findByIdentifier(identifier);
+
+        /**
+         * 조회된 유저를 바탕으로 음악 일기 찾기
+         */
+
+
+        DiaryResponse data1 =
+                new DiaryResponse("목데이터1", "https://www.youtube-nocookie.com/embed/ki08IcGubwQ");
+
+        DiaryResponse data2 =
+                new DiaryResponse("목데이터2", "https://www.youtube-nocookie.com/embed/ki08IcGubwQ");
+
+        DiaryResponse data3 =
+                new DiaryResponse("목데이터1", "https://www.youtube-nocookie.com/embed/ki08IcGubwQ");
+
+        DiaryResponse data4 =
+                new DiaryResponse("목데이터2", "https://www.youtube-nocookie.com/embed/ki08IcGubwQ");
+
+        List<DiaryResponse> datas = List.of(data1, data2, data3, data4);
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), datas.size());
+        List<DiaryResponse> subList = datas.subList(start, end);
+
+        return new PageImpl<>(subList, pageable, datas.size());
+
+    }
+}

--- a/src/main/java/apptive/team5/filter/JWTFilter.java
+++ b/src/main/java/apptive/team5/filter/JWTFilter.java
@@ -1,6 +1,7 @@
 package apptive.team5.filter;
 
 import apptive.team5.global.exception.NotFoundEntityException;
+import apptive.team5.jwt.TokenType;
 import apptive.team5.jwt.component.JWTUtil;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.service.UserLowService;
@@ -46,7 +47,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String accessToken = authorization.split(" ")[1];
 
-        if (!jwtUtil.validateToken(accessToken, true)) {
+        if (!jwtUtil.validateToken(accessToken, TokenType.ACCESS_TOKEN)) {
 
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/apptive/team5/global/DefaultImageProperties.java
+++ b/src/main/java/apptive/team5/global/DefaultImageProperties.java
@@ -1,0 +1,14 @@
+package apptive.team5.global;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "default-image")
+@Getter
+@Setter
+public class DefaultImageProperties {
+
+    private String profile;
+
+}

--- a/src/main/java/apptive/team5/jwt/TokenType.java
+++ b/src/main/java/apptive/team5/jwt/TokenType.java
@@ -1,0 +1,6 @@
+package apptive.team5.jwt;
+
+public enum TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+}

--- a/src/main/java/apptive/team5/jwt/component/JWTUtil.java
+++ b/src/main/java/apptive/team5/jwt/component/JWTUtil.java
@@ -1,5 +1,6 @@
 package apptive.team5.jwt.component;
 
+import apptive.team5.jwt.TokenType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,14 +31,13 @@ public class JWTUtil {
                 .getPayload();
     }
 
-    public boolean validateToken(String token, Boolean isAccess) {
+    public boolean validateToken(String token, TokenType tokenType) {
         try {
             Claims claims = getClaims(token);
-            String tokenType = claims.get("tokenType").toString();
+            String realTokenType = claims.get("tokenType").toString();
 
             if (tokenType == null) return false;
-            if (isAccess && tokenType.equals("refresh")) return false;
-            if (!isAccess && tokenType.equals("access")) return false;
+            if (!realTokenType.equals(tokenType.name())) return false;
 
             return true;
         } catch (Exception ex) {
@@ -46,18 +46,18 @@ public class JWTUtil {
     }
 
 
-    public String createJWT(String identifier, String role, Boolean isAccess) {
+    public String createJWT(String identifier, String role, TokenType tokenType) {
 
         long expiredMs;
         String type;
 
-        if (isAccess) {
+        if (tokenType.equals(TokenType.ACCESS_TOKEN)) {
             expiredMs = accessTokenExpiresIn;
-            type = "access";
+            type = TokenType.ACCESS_TOKEN.name();
         }
         else {
             expiredMs = refreshTokenExpiresIn;
-            type = "refresh";
+            type = TokenType.REFRESH_TOKEN.name();
         }
 
         return Jwts.builder()
@@ -70,15 +70,15 @@ public class JWTUtil {
                 .compact();
     }
 
-    public String createJWT(String identifier, String role, Boolean isAccess, Long expiredMs) {
+    public String createJWT(String identifier, String role, TokenType tokenType, Long expiredMs) {
 
         String type;
 
-        if (isAccess) {
-            type = "access";
+        if (tokenType.equals(TokenType.ACCESS_TOKEN)) {
+            type = TokenType.ACCESS_TOKEN.name();
         }
         else {
-            type = "refresh";
+            type = TokenType.REFRESH_TOKEN.name();
         }
 
         return Jwts.builder()

--- a/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
+++ b/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
@@ -26,7 +26,7 @@ public class RefreshToken {
     @Column(unique = true, nullable = false)
     private String token;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true, nullable = false)
     private UserEntity user;
 

--- a/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
+++ b/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
@@ -26,7 +26,7 @@ public class RefreshToken {
     @Column(unique = true, nullable = false)
     private String token;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", unique = true, nullable = false)
     private UserEntity user;
 

--- a/src/main/java/apptive/team5/jwt/service/JwtService.java
+++ b/src/main/java/apptive/team5/jwt/service/JwtService.java
@@ -2,6 +2,7 @@ package apptive.team5.jwt.service;
 
 import apptive.team5.global.exception.AuthenticationException;
 import apptive.team5.global.exception.ExceptionCode;
+import apptive.team5.jwt.TokenType;
 import apptive.team5.jwt.component.JWTUtil;
 import apptive.team5.jwt.domain.RefreshToken;
 import apptive.team5.jwt.dto.TokenResponse;
@@ -45,7 +46,7 @@ public class JwtService {
 
         if (oldRefreshToken == null) throw new AuthenticationException(ExceptionCode.NOT_EXIST_REFRESH_TOKEN.getDescription());
 
-        if (!jwtUtil.validateToken(oldRefreshToken, false))
+        if (!jwtUtil.validateToken(oldRefreshToken, TokenType.REFRESH_TOKEN))
             throw new AuthenticationException(ExceptionCode.INVALID_REFRESH_TOKEN.getDescription());
 
         Claims claims = jwtUtil.getClaims(oldRefreshToken);
@@ -58,8 +59,8 @@ public class JwtService {
             throw new AuthenticationException(ExceptionCode.INVALID_REFRESH_TOKEN.getDescription());
         }
 
-        String newAccessToken = jwtUtil.createJWT(identifier, role, true);
-        String newRefreshToken = jwtUtil.createJWT(identifier, role, false);
+        String newAccessToken = jwtUtil.createJWT(identifier, role, TokenType.ACCESS_TOKEN);
+        String newRefreshToken = jwtUtil.createJWT(identifier, role, TokenType.REFRESH_TOKEN);
 
         saveRefreshToken(identifier, newRefreshToken);
 

--- a/src/main/java/apptive/team5/user/controller/UserController.java
+++ b/src/main/java/apptive/team5/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package apptive.team5.user.controller;
+
+import apptive.team5.user.dto.UserResponse;
+import apptive.team5.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/my")
+    public ResponseEntity<UserResponse> getMyInfo(@AuthenticationPrincipal String identifier) {
+
+        UserResponse response = userService.getUserInfo(identifier);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
 
+    private static String defaultImage;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -39,12 +41,16 @@ public class UserEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private RefreshToken refreshToken;
 
+    @Column(nullable = false)
+    private String profileImageUrl;
+
     public UserEntity(String identifier, String email, String username, UserRoleType roleType, SocialType socialType) {
         this.identifier = identifier;
         this.email = email;
         this.username = username;
         this.roleType = roleType;
         this.socialType = socialType;
+        this.profileImageUrl = defaultImage;
     }
 
     public UserEntity(Long id, String identifier, String email, String username, UserRoleType roleType, SocialType socialType) {
@@ -54,6 +60,7 @@ public class UserEntity {
         this.username = username;
         this.roleType = roleType;
         this.socialType = socialType;
+        this.profileImageUrl = defaultImage;
     }
 
     public UserEntity(OAuth2Response oAuth2Response) {
@@ -62,5 +69,9 @@ public class UserEntity {
         this.username = oAuth2Response.getUsername();
         this.roleType = UserRoleType.USER;
         this.socialType = oAuth2Response.getProvider();
+    }
+
+    public static void setDefaultImage(String url) {
+        defaultImage = url;
     }
 }

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -38,7 +38,7 @@ public class UserEntity {
     @Column(nullable = false)
     private SocialType socialType;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch =  FetchType.EAGER)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch =  FetchType.LAZY)
     private RefreshToken refreshToken;
 
     @Column(nullable = false)

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -38,7 +38,7 @@ public class UserEntity {
     @Column(nullable = false)
     private SocialType socialType;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch =  FetchType.EAGER)
     private RefreshToken refreshToken;
 
     @Column(nullable = false)

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -1,5 +1,6 @@
 package apptive.team5.user.domain;
 
+import apptive.team5.jwt.domain.RefreshToken;
 import apptive.team5.oauth2.dto.OAuth2Response;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,6 +35,9 @@ public class UserEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SocialType socialType;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private RefreshToken refreshToken;
 
     public UserEntity(String identifier, String email, String username, UserRoleType roleType, SocialType socialType) {
         this.identifier = identifier;

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -47,6 +47,15 @@ public class UserEntity {
         this.socialType = socialType;
     }
 
+    public UserEntity(Long id, String identifier, String email, String username, UserRoleType roleType, SocialType socialType) {
+        this.id = id;
+        this.identifier = identifier;
+        this.email = email;
+        this.username = username;
+        this.roleType = roleType;
+        this.socialType = socialType;
+    }
+
     public UserEntity(OAuth2Response oAuth2Response) {
         this.identifier = oAuth2Response.getProvider() + "-" + oAuth2Response.getProviderId();
         this.email = oAuth2Response.getEmail();

--- a/src/main/java/apptive/team5/user/dto/UserResponse.java
+++ b/src/main/java/apptive/team5/user/dto/UserResponse.java
@@ -1,0 +1,20 @@
+package apptive.team5.user.dto;
+
+import apptive.team5.user.domain.SocialType;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.domain.UserRoleType;
+
+public record UserResponse(
+        String username,
+        String identifier,
+        String email,
+        String profileImageUrl,
+        UserRoleType userRoleType,
+        SocialType socialType
+) {
+
+    public UserResponse(UserEntity userEntity) {
+        this(userEntity.getUsername(), userEntity.getIdentifier(), userEntity.getEmail(),
+                userEntity.getProfileImageUrl(), userEntity.getRoleType(), userEntity.getSocialType());
+    }
+}

--- a/src/main/java/apptive/team5/user/dto/UserResponse.java
+++ b/src/main/java/apptive/team5/user/dto/UserResponse.java
@@ -14,7 +14,11 @@ public record UserResponse(
 ) {
 
     public UserResponse(UserEntity userEntity) {
-        this(userEntity.getUsername(), userEntity.getIdentifier(), userEntity.getEmail(),
-                userEntity.getProfileImageUrl(), userEntity.getRoleType(), userEntity.getSocialType());
+        this(userEntity.getUsername(),
+                userEntity.getIdentifier(),
+                userEntity.getEmail(),
+                userEntity.getProfileImageUrl(),
+                userEntity.getRoleType(),
+                userEntity.getSocialType());
     }
 }

--- a/src/main/java/apptive/team5/user/service/UserService.java
+++ b/src/main/java/apptive/team5/user/service/UserService.java
@@ -7,6 +7,7 @@ import apptive.team5.jwt.service.JwtService;
 import apptive.team5.oauth2.dto.OAuth2Response;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.domain.UserRoleType;
+import apptive.team5.user.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +39,12 @@ public class UserService {
         jwtService.saveRefreshToken(user.getIdentifier(), refreshToken);
 
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public UserResponse getUserInfo(String identifier) {
+        UserEntity findUser = userLowService.findByIdentifier(identifier);
+
+        return new UserResponse(findUser);
     }
 
 

--- a/src/main/java/apptive/team5/user/service/UserService.java
+++ b/src/main/java/apptive/team5/user/service/UserService.java
@@ -1,4 +1,5 @@
 package apptive.team5.user.service;
+import apptive.team5.jwt.TokenType;
 import apptive.team5.jwt.component.JWTUtil;
 import apptive.team5.jwt.dto.TokenResponse;
 import apptive.team5.jwt.repository.RefreshTokenRepository;
@@ -30,8 +31,8 @@ public class UserService {
             user = userLowService.save(new UserEntity(identifier, oAuth2Response.getEmail(), oAuth2Response.getUsername(), UserRoleType.USER, oAuth2Response.getProvider()));
         }
 
-        String accessToken = jwtUtil.createJWT(user.getIdentifier(), "ROLE_" + user.getRoleType().name(), true);
-        String refreshToken = jwtUtil.createJWT(user.getIdentifier(), "ROLE_" + user.getRoleType().name(), false);
+        String accessToken = jwtUtil.createJWT(user.getIdentifier(), "ROLE_" + user.getRoleType().name(), TokenType.ACCESS_TOKEN);
+        String refreshToken = jwtUtil.createJWT(user.getIdentifier(), "ROLE_" + user.getRoleType().name(), TokenType.REFRESH_TOKEN);
 
 
         jwtService.saveRefreshToken(user.getIdentifier(), refreshToken);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,4 @@ spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.ser
 spring.jwt.secret=${JWT_KEY}
 spring.secretBase64=${SECRET_BASE64}
 youtube.api.key=${YOUTUBE_KEY}
+default-image.profile=${PROFILE_DEFAULT_IMAGE}

--- a/src/test/java/apptive/team5/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/apptive/team5/jwt/controller/JwtControllerTest.java
@@ -2,6 +2,7 @@ package apptive.team5.jwt.controller;
 
 
 import apptive.team5.global.exception.ExceptionCode;
+import apptive.team5.jwt.TokenType;
 import apptive.team5.jwt.component.JWTUtil;
 import apptive.team5.jwt.dto.TokenResponse;
 import apptive.team5.jwt.service.JwtService;
@@ -52,7 +53,7 @@ class JwtControllerTest {
         UserEntity user = TestUtil.makeUserEntity();
         UserEntity userEntity = userLowService.save(user);
 
-        String refreshToken = jwtUtil.createJWT(userEntity.getIdentifier(), userEntity.getRoleType().name(), false);
+        String refreshToken = jwtUtil.createJWT(userEntity.getIdentifier(), userEntity.getRoleType().name(), TokenType.REFRESH_TOKEN);
 
         jwtService.saveRefreshToken(userEntity.getIdentifier(), refreshToken);
 
@@ -92,7 +93,7 @@ class JwtControllerTest {
         UserEntity user = TestUtil.makeUserEntity();
         UserEntity userEntity = userLowService.save(user);
 
-        String refreshToken = jwtUtil.createJWT(userEntity.getIdentifier(), userEntity.getRoleType().name(), false, 0L);
+        String refreshToken = jwtUtil.createJWT(userEntity.getIdentifier(), userEntity.getRoleType().name(), TokenType.REFRESH_TOKEN, 0L);
 
         mockMvc.perform(post("/api/jwt/exchange")
                         .header("X-Refresh-Token", refreshToken))

--- a/src/test/java/apptive/team5/jwt/service/JwtServiceTest.java
+++ b/src/test/java/apptive/team5/jwt/service/JwtServiceTest.java
@@ -88,7 +88,7 @@ class JwtServiceTest {
     void exchangeTokenSuccess() {
         // given
 
-        given(jwtUtil.validateToken(any(), anyBoolean()))
+        given(jwtUtil.validateToken(any(), any()))
                 .willReturn(true);
 
         Claims claims = mock(Claims.class);
@@ -134,7 +134,7 @@ class JwtServiceTest {
         verify(refreshTokenRepository).deleteByUser(any());
         verify(refreshTokenRepository).save(any());
         verify(jwtUtil).getClaims(any());
-        verify(jwtUtil).validateToken(any(), anyBoolean());
+        verify(jwtUtil).validateToken(any(), any());
         verify(jwtUtil, times(2)).createJWT(any(), any(), any());
         verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository);
     }
@@ -162,14 +162,14 @@ class JwtServiceTest {
         // given
 
 
-        given(jwtUtil.validateToken(any(), anyBoolean()))
+        given(jwtUtil.validateToken(any(), any()))
                 .willReturn(false);
 
         // when & then
         assertThatThrownBy(()->jwtService.exchangeToken("refreshToken"))
                 .isInstanceOf(AuthenticationException.class)
                 .hasMessage(ExceptionCode.INVALID_REFRESH_TOKEN.getDescription());
-        verify(jwtUtil).validateToken(any(), anyBoolean());
+        verify(jwtUtil).validateToken(any(), any());
         verifyNoMoreInteractions(userLowService, jwtUtil, refreshTokenRepository);
     }
 

--- a/src/test/java/apptive/team5/user/controller/UserControllerTest.java
+++ b/src/test/java/apptive/team5/user/controller/UserControllerTest.java
@@ -1,0 +1,91 @@
+package apptive.team5.user.controller;
+
+import apptive.team5.global.exception.ExceptionCode;
+import apptive.team5.jwt.TokenType;
+import apptive.team5.jwt.component.JWTUtil;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.dto.UserResponse;
+import apptive.team5.user.repository.UserRepository;
+import apptive.team5.util.TestUtil;
+import apptive.team5.util.mockuser.WithCustomMockUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JWTUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @DisplayName("회원 정보 조회 성공")
+    @Test
+    @WithCustomMockUser(identifier = TestUtil.userIdentifier)
+    void getMyInfoSuccess() throws Exception {
+
+        UserEntity user = TestUtil.makeUserEntity();
+        userRepository.save(user);
+
+        String response = mockMvc.perform(get("/api/users/my"))
+                .andReturn().getResponse().getContentAsString();
+
+        UserResponse userResponse = objectMapper.readValue(response, UserResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(userResponse.email()).isEqualTo(user.getEmail());
+            softly.assertThat(userResponse.identifier()).isEqualTo(user.getIdentifier());
+            softly.assertThat(userResponse.socialType()).isEqualTo(user.getSocialType());
+            softly.assertThat(userResponse.userRoleType()).isEqualTo(user.getRoleType());
+            softly.assertThat(userResponse.profileImageUrl()).isEqualTo(user.getProfileImageUrl());
+        });
+    }
+
+    @DisplayName("회원 정보 조회 실패 - 존재하지 않는 회원")
+    @Test
+    @WithCustomMockUser
+    void getMyInfoFail() throws Exception {
+
+
+        MockHttpServletResponse response = mockMvc.perform(get("/api/users/my"))
+                .andReturn().getResponse();
+
+        String content = response.getContentAsString();
+
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            softly.assertThat(content.contains(ExceptionCode.NOT_FOUND_USER.getDescription()));
+        });
+
+    }
+
+
+}

--- a/src/test/java/apptive/team5/util/mockuser/WithCustomMockUser.java
+++ b/src/test/java/apptive/team5/util/mockuser/WithCustomMockUser.java
@@ -13,6 +13,6 @@ import java.lang.annotation.*;
 )
 public @interface WithCustomMockUser {
 
-    String identifier() default "GOOGLE_1234";
+    String identifier() default "GOOGLE-1234";
     String role() default "ROLE_USER";
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,3 +18,4 @@ spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.ser
 spring.jwt.secret=${JWT_KEY}
 spring.secretBase64=${SECRET_BASE64}
 youtube.api.key=${YOUTUBE_KEY}
+default-image.profile=${PROFILE_DEFAULT_IMAGE}


### PR DESCRIPTION
# 변경점 👍
1. 리프래시 토큰을 기기당 한개 소유할 수 있게 변경 (`@OneToOne`), 토큰 유형을 enum으로 관리
2. 유저 기본 프로필 이미지 설정(S3 url 저장중)
3. 본인의 음악 일기(목데이터) 반환하는 api 구현 (`/api/diaries/my`)
4. 본인 정보 조회 api 구현 (`/api/users/my`)

 
# 비고 ✏
프로필 이미지 변경은 아직 구현 안함 (다음 스프린트에..?, 프론트랑 PresignedUrl 관련해서 협의 해야함)
음악 일기에 대한 CRUD가 완성되면 목데이터말고 실제 데이터 반환하기

