### PR TITLE
다이어리 필드 추가 및 유튜브 api 응답 정렬 기준 추가

### DIFF
--- a/src/main/java/apptive/team5/diary/controller/DiaryController.java
+++ b/src/main/java/apptive/team5/diary/controller/DiaryController.java
@@ -1,5 +1,6 @@
 package apptive.team5.diary.controller;
 
+import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.dto.DiaryCreateRequest;
 import apptive.team5.diary.dto.DiaryResponse;
 import apptive.team5.diary.dto.DiaryUpdateRequest;
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,9 +48,9 @@ public class DiaryController {
 
     @PostMapping
     public ResponseEntity<Void> createDiary(@AuthenticationPrincipal String identifier, @Valid @RequestBody DiaryCreateRequest diaryRequest) {
-        diaryService.createDiary(identifier, diaryRequest);
+        DiaryEntity diary = diaryService.createDiary(identifier, diaryRequest);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).location(URI.create("/api/diaries/" + diary.getId())).build();
     }
 
     @PutMapping("/{diaryId}")

--- a/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
+++ b/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
@@ -1,5 +1,6 @@
 package apptive.team5.diary.domain;
 
+import apptive.team5.global.entity.BaseTimeEntity;
 import apptive.team5.user.domain.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +23,7 @@ import org.springframework.security.access.AccessDeniedException;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DiaryEntity {
+public class DiaryEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
+++ b/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
@@ -34,15 +34,22 @@ public class DiaryEntity extends BaseTimeEntity {
     private String musicTitle;
     @Column(nullable = false, length = 255)
     private String artist;
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String albumImageUrl;
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String videoUrl;
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DiaryScope scope;
+
+    @Column(nullable = false)
+    private String duration;
+    @Column(nullable = false)
+    private String start;
+    @Column(nullable = false)
+    private String end;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
@@ -59,6 +66,9 @@ public class DiaryEntity extends BaseTimeEntity {
             String videoUrl,
             String content,
             DiaryScope scope,
+            String duration,
+            String start,
+            String end,
             UserEntity user
     ) {
         this(
@@ -69,6 +79,9 @@ public class DiaryEntity extends BaseTimeEntity {
                 videoUrl,
                 content,
                 scope,
+                duration,
+                start,
+                end,
                 user
         );
     }

--- a/src/main/java/apptive/team5/diary/dto/DiaryCreateRequest.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryCreateRequest.java
@@ -18,7 +18,13 @@ public record DiaryCreateRequest(
         @NotBlank(message = "내용을 입력해주세요")
         String content,
         @NotNull(message = "공개 범위는 필수 입력입니다.")
-        DiaryScope scope
+        DiaryScope scope,
+        @NotBlank(message = "영상 길이는 필수 입력입니다.")
+        String duration,
+        @NotBlank(message = "킬링파트 시작 시간은 필수 입력입니다.")
+        String start,
+        @NotBlank(message = "킬링파트 종료 시간은 필수 입력입니다.")
+        String end
 ) {
         public static DiaryEntity toEntity(DiaryCreateRequest diaryRequest, UserEntity user) {
                 return new DiaryEntity(
@@ -28,6 +34,9 @@ public record DiaryCreateRequest(
                         diaryRequest.videoUrl,
                         diaryRequest.content,
                         diaryRequest.scope,
+                        diaryRequest.duration,
+                        diaryRequest.start(),
+                        diaryRequest.end,
                         user
                 );
         }

--- a/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
@@ -4,6 +4,8 @@ package apptive.team5.diary.dto;
 import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryScope;
 
+import java.time.LocalDate;
+
 public record DiaryResponse(
         String artist,
         String musicTitle,
@@ -13,7 +15,9 @@ public record DiaryResponse(
         DiaryScope scope,
         String duration,
         String start,
-        String end
+        String end,
+        LocalDate createDate,
+        LocalDate updateDate
 ) {
     public static DiaryResponse from(DiaryEntity diary) {
         return new DiaryResponse(
@@ -25,7 +29,9 @@ public record DiaryResponse(
                 diary.getScope(),
                 diary.getDuration(),
                 diary.getStart(),
-                diary.getEnd()
+                diary.getEnd(),
+                diary.getCreateDateTime().toLocalDate(),
+                diary.getUpdateDateTime().toLocalDate()
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
@@ -10,7 +10,10 @@ public record DiaryResponse(
         String albumImageUrl,
         String content,
         String videoUrl,
-        DiaryScope scope
+        DiaryScope scope,
+        String duration,
+        String start,
+        String end
 ) {
     public static DiaryResponse from(DiaryEntity diary) {
         return new DiaryResponse(
@@ -19,7 +22,10 @@ public record DiaryResponse(
                 diary.getAlbumImageUrl(),
                 diary.getContent(),
                 diary.getVideoUrl(),
-                diary.getScope()
+                diary.getScope(),
+                diary.getDuration(),
+                diary.getStart(),
+                diary.getEnd()
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryResponse.java
@@ -3,8 +3,7 @@ package apptive.team5.diary.dto;
 
 import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryScope;
-
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record DiaryResponse(
         String artist,
@@ -16,8 +15,8 @@ public record DiaryResponse(
         String duration,
         String start,
         String end,
-        LocalDate createDate,
-        LocalDate updateDate
+        LocalDateTime createDate,
+        LocalDateTime updateDate
 ) {
     public static DiaryResponse from(DiaryEntity diary) {
         return new DiaryResponse(
@@ -30,8 +29,8 @@ public record DiaryResponse(
                 diary.getDuration(),
                 diary.getStart(),
                 diary.getEnd(),
-                diary.getCreateDateTime().toLocalDate(),
-                diary.getUpdateDateTime().toLocalDate()
+                diary.getCreateDateTime(),
+                diary.getUpdateDateTime()
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryUpdateDto.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryUpdateDto.java
@@ -8,6 +8,9 @@ public record DiaryUpdateDto(
         String albumImageUrl,
         String videoUrl,
         String content,
-        DiaryScope scope
+        DiaryScope scope,
+        String duration,
+        String start,
+        String end
 ) {
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequest.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequest.java
@@ -8,7 +8,10 @@ public record DiaryUpdateRequest(
         String albumImageUrl,
         String videoUrl,
         String content,
-        DiaryScope scope
+        DiaryScope scope,
+        String duration,
+        String start,
+        String end
 ) {
     public static DiaryUpdateDto toUpdateDto(DiaryUpdateRequest updateRequest) {
         return new DiaryUpdateDto(
@@ -17,7 +20,10 @@ public record DiaryUpdateRequest(
                 updateRequest.albumImageUrl,
                 updateRequest.videoUrl,
                 updateRequest.content,
-                updateRequest.scope
+                updateRequest.scope,
+                updateRequest.duration(),
+                updateRequest.start(),
+                updateRequest.end()
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequest.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequest.java
@@ -21,9 +21,9 @@ public record DiaryUpdateRequest(
                 updateRequest.videoUrl,
                 updateRequest.content,
                 updateRequest.scope,
-                updateRequest.duration(),
-                updateRequest.start(),
-                updateRequest.end()
+                updateRequest.duration,
+                updateRequest.start,
+                updateRequest.end
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/service/DiaryLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLowService.java
@@ -17,8 +17,8 @@ public class DiaryLowService {
     private final DiaryRepository diaryRepository;
 
     @Transactional
-    public void saveDiary(DiaryEntity diary) {
-        diaryRepository.save(diary);
+    public DiaryEntity saveDiary(DiaryEntity diary) {
+        return diaryRepository.save(diary);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -28,12 +28,12 @@ public class DiaryService {
     }
 
     @Transactional
-    public void createDiary(String identifier, DiaryCreateRequest diaryRequest) {
+    public DiaryEntity createDiary(String identifier, DiaryCreateRequest diaryRequest) {
         UserEntity foundUser = findUserByIdentifier(identifier);
 
         DiaryEntity diary = DiaryCreateRequest.toEntity(diaryRequest, foundUser);
 
-        diaryLowService.saveDiary(diary);
+        return diaryLowService.saveDiary(diary);
     }
 
     @Transactional

--- a/src/main/java/apptive/team5/global/entity/BaseTimeEntity.java
+++ b/src/main/java/apptive/team5/global/entity/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package apptive.team5.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createDateTime;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updateDateTime;
+}
+

--- a/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
+++ b/src/main/java/apptive/team5/jwt/domain/RefreshToken.java
@@ -1,5 +1,6 @@
 package apptive.team5.jwt.domain;
 
+import apptive.team5.global.entity.BaseTimeEntity;
 import apptive.team5.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/apptive/team5/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/apptive/team5/oauth2/controller/OAuth2Controller.java
@@ -22,8 +22,6 @@ public class OAuth2Controller {
 
         TokenResponse tokenResponse = kakaoService.kakaoLogin(kakaoLoginRequest.accessToken());
 
-        System.out.println(tokenResponse.accessToken());
-
         return ResponseEntity.ok(tokenResponse);
     }
 

--- a/src/main/java/apptive/team5/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/apptive/team5/oauth2/controller/OAuth2Controller.java
@@ -22,6 +22,8 @@ public class OAuth2Controller {
 
         TokenResponse tokenResponse = kakaoService.kakaoLogin(kakaoLoginRequest.accessToken());
 
+        System.out.println(tokenResponse.accessToken());
+
         return ResponseEntity.ok(tokenResponse);
     }
 

--- a/src/main/java/apptive/team5/user/domain/UserEntity.java
+++ b/src/main/java/apptive/team5/user/domain/UserEntity.java
@@ -1,5 +1,6 @@
 package apptive.team5.user.domain;
 
+import apptive.team5.global.entity.BaseTimeEntity;
 import apptive.team5.jwt.domain.RefreshToken;
 import apptive.team5.oauth2.dto.OAuth2Response;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserEntity {
+public class UserEntity extends BaseTimeEntity {
 
     private static String defaultImage;
 

--- a/src/main/java/apptive/team5/youtube/dto/YoutubeVideoResponse.java
+++ b/src/main/java/apptive/team5/youtube/dto/YoutubeVideoResponse.java
@@ -6,10 +6,23 @@ public record YoutubeVideoResponse (
         String title,
         String duration,
         String url
-){
+) implements Comparable<YoutubeVideoResponse> {
 
     public YoutubeVideoResponse(Video video) {
         this(video.getSnippet().getTitle(), video.getContentDetails().getDuration(),
                 "https://www.youtube-nocookie.com/embed/" + video.getId());
+    }
+
+    @Override
+    public int compareTo(YoutubeVideoResponse other) {
+        return Integer.compare(priority(this.title), priority(other.title));
+    }
+
+    private int priority(String title) {
+        if (title.contains("Official Audio")) return 1;
+        if (title.contains("Lyrics")) return 2;
+        if (title.contains("가사")) return 3;
+        if (title.contains("Official MV")) return 4;
+        return 5;
     }
 }

--- a/src/main/java/apptive/team5/youtube/service/YoutubeService.java
+++ b/src/main/java/apptive/team5/youtube/service/YoutubeService.java
@@ -53,7 +53,9 @@ public class YoutubeService {
                     .execute();
 
             return videoResponse.getItems()
-                    .stream().map(YoutubeVideoResponse::new).toList();
+                    .stream().map(YoutubeVideoResponse::new)
+                    .sorted()
+                    .toList();
 
         } catch (IOException e) {
             throw new ExternalApiConnectException(ExceptionCode.YOUTUBE_API_EXCEPTION.getDescription(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/test/java/apptive/team5/util/TestUtil.java
+++ b/src/test/java/apptive/team5/util/TestUtil.java
@@ -32,6 +32,9 @@ public final class TestUtil {
                 "video.url",
                 "Test content",
                 DiaryScope.PUBLIC,
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S",
                 user
         );
     }
@@ -45,6 +48,9 @@ public final class TestUtil {
                 "video.url",
                 "Test content",
                 DiaryScope.PUBLIC,
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S",
                 user
         );
     }
@@ -56,7 +62,10 @@ public final class TestUtil {
                 "image.url",
                 "url",
                 "Test Content",
-                DiaryScope.PUBLIC
+                DiaryScope.PUBLIC,
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S"
         );
     }
 
@@ -67,7 +76,10 @@ public final class TestUtil {
                 "updated.image.url",
                 "updated.video.url",
                 "Updated Content",
-                DiaryScope.PUBLIC
+                DiaryScope.PUBLIC,
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S"
         );
     }
 }


### PR DESCRIPTION
# 변경점 👍
close: #7  
1. DiaryEntity에 duration, start, end 추가
2. 유튜브 api 응답 정렬기준 추가 (Official Audio, Lyrics, 가사, Official MV, 나머지) 순으로 정렬
3. BaseTimeEntity 추가
    
# 비고 ✏
 
테스트에서 응답값 검증할 때 `SoftAssertions.assertSoftly` 사용했으면 좋겠습니다.
참고 : https://zzang9ha.tistory.com/418
