### PR TITLE
feat: 알람 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,15 @@ jobs:
       - name: 테스트 환경변수 주입
         run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" > ./src/test/resources/application.properties
 
+      - name: fcm.json 파일 주입
+        id: create-json
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: "killing-part-32870-firebase-adminsdk-fbsvc-f5c0d13f5b.json"
+          json: ${{ secrets.FIREBASE_KEY }}
+          dir: 'src/main/resources/firebase/'
+
+
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: 테스트 환경변수 주입
         run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" > ./src/test/resources/application.properties
 
+      - name: firebase 디렉토리 생성
+        run: mkdir -p ./src/main/resources/firebase
+
       - name: fcm.json 파일 주입
         id: create-json
         uses: jsdaniell/create-json@v1.2.2

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 .env
 src/main/resources/application-prod.properties
 src/test/resources/application-prod.properties
+src/main/resources/firebase/

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.1.0'
+
+	// firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 

--- a/src/main/java/apptive/team5/alarm/controller/AlarmController.java
+++ b/src/main/java/apptive/team5/alarm/controller/AlarmController.java
@@ -1,0 +1,37 @@
+package apptive.team5.alarm.controller;
+
+import apptive.team5.alarm.dto.AlarmResponse;
+import apptive.team5.alarm.service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/alarms")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @GetMapping
+    public ResponseEntity<Page<AlarmResponse>> getAlarms(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "5") int size,
+            @AuthenticationPrincipal Long userId
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<AlarmResponse> alarms = alarmService.getAlarms(userId, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK).body(alarms);
+    }
+}

--- a/src/main/java/apptive/team5/alarm/controller/AlarmController.java
+++ b/src/main/java/apptive/team5/alarm/controller/AlarmController.java
@@ -29,7 +29,14 @@ public class AlarmController {
             @RequestParam(name = "size", defaultValue = "5") int size,
             @AuthenticationPrincipal Long userId
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(
+                        Sort.Order.desc("createDateTime"),
+                        Sort.Order.desc("id")
+                )
+        );
         Page<AlarmResponse> alarms = alarmService.getAlarms(userId, pageable);
 
         return ResponseEntity.status(HttpStatus.OK).body(alarms);

--- a/src/main/java/apptive/team5/alarm/dto/AlarmResponse.java
+++ b/src/main/java/apptive/team5/alarm/dto/AlarmResponse.java
@@ -1,0 +1,19 @@
+package apptive.team5.alarm.dto;
+
+
+import apptive.team5.alarm.entity.Alarm;
+
+public record AlarmResponse(
+        Long alarmId,
+        String title,
+        String content
+) {
+
+    public AlarmResponse(Alarm alarm) {
+        this(
+                alarm.getId(),
+                alarm.getTitle(),
+                alarm.getContent()
+        );
+    }
+}

--- a/src/main/java/apptive/team5/alarm/dto/AlarmResponse.java
+++ b/src/main/java/apptive/team5/alarm/dto/AlarmResponse.java
@@ -6,14 +6,16 @@ import apptive.team5.alarm.entity.Alarm;
 public record AlarmResponse(
         Long alarmId,
         String title,
-        String content
+        String content,
+        String deepLink
 ) {
 
     public AlarmResponse(Alarm alarm) {
         this(
                 alarm.getId(),
                 alarm.getTitle(),
-                alarm.getContent()
+                alarm.getContent(),
+                alarm.getDeepLink()
         );
     }
 }

--- a/src/main/java/apptive/team5/alarm/dto/AlarmSendRequest.java
+++ b/src/main/java/apptive/team5/alarm/dto/AlarmSendRequest.java
@@ -3,8 +3,7 @@ package apptive.team5.alarm.dto;
 import apptive.team5.user.domain.UserEntity;
 
 public record AlarmSendRequest(
-        UserEntity receiver,
-        String title,
-        String content
+        Long diaryId,
+        Long actorId
 ) {
 }

--- a/src/main/java/apptive/team5/alarm/dto/AlarmSendRequest.java
+++ b/src/main/java/apptive/team5/alarm/dto/AlarmSendRequest.java
@@ -1,0 +1,10 @@
+package apptive.team5.alarm.dto;
+
+import apptive.team5.user.domain.UserEntity;
+
+public record AlarmSendRequest(
+        UserEntity receiver,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/apptive/team5/alarm/entity/Alarm.java
+++ b/src/main/java/apptive/team5/alarm/entity/Alarm.java
@@ -1,6 +1,7 @@
 package apptive.team5.alarm.entity;
 
 
+import apptive.team5.global.entity.BaseTimeEntity;
 import apptive.team5.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Alarm {
+public class Alarm extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/apptive/team5/alarm/entity/Alarm.java
+++ b/src/main/java/apptive/team5/alarm/entity/Alarm.java
@@ -1,0 +1,39 @@
+package apptive.team5.alarm.entity;
+
+
+import apptive.team5.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false
+    )
+    private UserEntity user;
+
+    public Alarm(String title, String content, UserEntity user) {
+        this.title = title;
+        this.content = content;
+        this.user = user;
+    }
+}

--- a/src/main/java/apptive/team5/alarm/entity/Alarm.java
+++ b/src/main/java/apptive/team5/alarm/entity/Alarm.java
@@ -24,6 +24,9 @@ public class Alarm {
     @Column(nullable = false, length = 1000)
     private String content;
 
+    @Column(nullable = false, length = 1000)
+    private String deepLink;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
             name = "user_id",
@@ -31,9 +34,10 @@ public class Alarm {
     )
     private UserEntity user;
 
-    public Alarm(String title, String content, UserEntity user) {
+    public Alarm(String title, String content, String deepLink, UserEntity user) {
         this.title = title;
         this.content = content;
+        this.deepLink = deepLink;
         this.user = user;
     }
 }

--- a/src/main/java/apptive/team5/alarm/entity/AlarmMessage.java
+++ b/src/main/java/apptive/team5/alarm/entity/AlarmMessage.java
@@ -1,0 +1,16 @@
+package apptive.team5.alarm.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AlarmMessage {
+
+    LIKE_ALARM("킬링파트에 좋아요가 도착했어요");
+
+    private final String message;
+
+
+    AlarmMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/apptive/team5/alarm/event/AlarmCreatedEvent.java
+++ b/src/main/java/apptive/team5/alarm/event/AlarmCreatedEvent.java
@@ -1,0 +1,8 @@
+package apptive.team5.alarm.event;
+
+public record AlarmCreatedEvent(
+        Long receiverId,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/apptive/team5/alarm/event/AlarmCreatedEvent.java
+++ b/src/main/java/apptive/team5/alarm/event/AlarmCreatedEvent.java
@@ -3,6 +3,7 @@ package apptive.team5.alarm.event;
 public record AlarmCreatedEvent(
         Long receiverId,
         String title,
-        String content
+        String content,
+        String deepLink
 ) {
 }

--- a/src/main/java/apptive/team5/alarm/event/AlarmEventListener.java
+++ b/src/main/java/apptive/team5/alarm/event/AlarmEventListener.java
@@ -1,0 +1,19 @@
+package apptive.team5.alarm.event;
+
+import apptive.team5.fcm.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmEventListener {
+
+    private final FcmService fcmService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAlarmCreated(AlarmCreatedEvent event) {
+        fcmService.sendAlarm(event.receiverId(), event.title(), event.content());
+    }
+}

--- a/src/main/java/apptive/team5/alarm/event/AlarmEventListener.java
+++ b/src/main/java/apptive/team5/alarm/event/AlarmEventListener.java
@@ -14,6 +14,6 @@ public class AlarmEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleAlarmCreated(AlarmCreatedEvent event) {
-        fcmService.sendAlarm(event.receiverId(), event.title(), event.content());
+        fcmService.sendAlarm(event.receiverId(), event.title(), event.content(), event.deepLink());
     }
 }

--- a/src/main/java/apptive/team5/alarm/repository/AlarmRepository.java
+++ b/src/main/java/apptive/team5/alarm/repository/AlarmRepository.java
@@ -1,0 +1,18 @@
+package apptive.team5.alarm.repository;
+
+import apptive.team5.alarm.entity.Alarm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+    @Query("select al from Alarm al where al.user.id = :userId")
+    Page<Alarm> findByUserIdWithPage(Long userId, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Alarm al where al.user.id = :userId")
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
@@ -2,9 +2,15 @@ package apptive.team5.alarm.service;
 
 import apptive.team5.alarm.dto.AlarmSendRequest;
 import apptive.team5.alarm.entity.Alarm;
+import apptive.team5.alarm.entity.AlarmMessage;
 import apptive.team5.alarm.event.AlarmCreatedEvent;
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.service.DiaryLowService;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,19 +20,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlarmDispatchService {
 
     private final AlarmLowService alarmLowService;
+    private final DiaryLowService diaryLowService;
+    private final UserLowService userLowService;
     private final ApplicationEventPublisher eventPublisher;
 
-    public void saveAndDispatch(AlarmSendRequest request) {
+    @Async("sendAlarm")
+    public void saveAndDispatchForLike(AlarmSendRequest request) {
+
+        Long actorId = request.actorId();
+        UserEntity actor = userLowService.findById(actorId);
+        DiaryEntity diary = diaryLowService.findByIdWithUser(request.diaryId());
+        UserEntity receiver = diary.getUser();
+
+        String title = AlarmMessage.LIKE_ALARM.getMessage();
+        String content = actor.getUsername() + "님이 회원님의 킬링파트를 좋아합니다.";
+
         alarmLowService.save(new Alarm(
-                request.title(),
-                request.content(),
-                request.receiver()
+                title,
+                content,
+                receiver
         ));
 
         eventPublisher.publishEvent(new AlarmCreatedEvent(
-                request.receiver().getId(),
-                request.title(),
-                request.content()
+                receiver.getId(),
+                title,
+                content
         ));
     }
 }

--- a/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
@@ -1,0 +1,32 @@
+package apptive.team5.alarm.service;
+
+import apptive.team5.alarm.dto.AlarmSendRequest;
+import apptive.team5.alarm.entity.Alarm;
+import apptive.team5.alarm.event.AlarmCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmDispatchService {
+
+    private final AlarmLowService alarmLowService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void saveAndDispatch(AlarmSendRequest request) {
+        alarmLowService.save(new Alarm(
+                request.title(),
+                request.content(),
+                request.receiver()
+        ));
+
+        eventPublisher.publishEvent(new AlarmCreatedEvent(
+                request.receiver().getId(),
+                request.title(),
+                request.content()
+        ));
+    }
+}

--- a/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmDispatchService.java
@@ -19,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlarmDispatchService {
 
+    private static final String DIARY_DEEP_LINK_FORMAT = "/diaries/%d";
+
     private final AlarmLowService alarmLowService;
     private final DiaryLowService diaryLowService;
     private final UserLowService userLowService;
@@ -34,17 +36,20 @@ public class AlarmDispatchService {
 
         String title = AlarmMessage.LIKE_ALARM.getMessage();
         String content = actor.getUsername() + "님이 회원님의 킬링파트를 좋아합니다.";
+        String deepLink = DIARY_DEEP_LINK_FORMAT.formatted(diary.getId());
 
         alarmLowService.save(new Alarm(
                 title,
                 content,
+                deepLink,
                 receiver
         ));
 
         eventPublisher.publishEvent(new AlarmCreatedEvent(
                 receiver.getId(),
                 title,
-                content
+                content,
+                deepLink
         ));
     }
 }

--- a/src/main/java/apptive/team5/alarm/service/AlarmLowService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmLowService.java
@@ -1,0 +1,31 @@
+package apptive.team5.alarm.service;
+
+import apptive.team5.alarm.entity.Alarm;
+import apptive.team5.alarm.repository.AlarmRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmLowService {
+
+    private final AlarmRepository alarmRepository;
+
+    @Transactional(readOnly = true)
+    public Page<Alarm> findByUserIdWithPage(Long memberId, Pageable pageable) {
+        return alarmRepository.findByUserIdWithPage(memberId, pageable);
+    }
+
+
+    public Alarm save(Alarm alarm) {
+        return alarmRepository.save(alarm);
+    }
+
+    public void deleteByUserId(Long memberId) {
+        alarmRepository.deleteByUserId(memberId);
+    }
+}

--- a/src/main/java/apptive/team5/alarm/service/AlarmLowService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmLowService.java
@@ -16,8 +16,8 @@ public class AlarmLowService {
     private final AlarmRepository alarmRepository;
 
     @Transactional(readOnly = true)
-    public Page<Alarm> findByUserIdWithPage(Long memberId, Pageable pageable) {
-        return alarmRepository.findByUserIdWithPage(memberId, pageable);
+    public Page<Alarm> findByUserIdWithPage(Long userId, Pageable pageable) {
+        return alarmRepository.findByUserIdWithPage(userId, pageable);
     }
 
 
@@ -25,7 +25,7 @@ public class AlarmLowService {
         return alarmRepository.save(alarm);
     }
 
-    public void deleteByUserId(Long memberId) {
-        alarmRepository.deleteByUserId(memberId);
+    public void deleteByUserId(Long userId) {
+        alarmRepository.deleteByUserId(userId);
     }
 }

--- a/src/main/java/apptive/team5/alarm/service/AlarmService.java
+++ b/src/main/java/apptive/team5/alarm/service/AlarmService.java
@@ -1,0 +1,28 @@
+package apptive.team5.alarm.service;
+
+import apptive.team5.alarm.dto.AlarmResponse;
+import apptive.team5.alarm.entity.Alarm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmLowService alarmLowService;
+
+    @Transactional(readOnly = true)
+    public Page<AlarmResponse> getAlarms(Long userId, Pageable pageable) {
+
+        return alarmLowService.findByUserIdWithPage(userId, pageable)
+                .map(AlarmResponse::new);
+    }
+
+    public Alarm save(Alarm alarm) {
+        return alarmLowService.save(alarm);
+    }
+}

--- a/src/main/java/apptive/team5/config/AsyncConfig.java
+++ b/src/main/java/apptive/team5/config/AsyncConfig.java
@@ -27,6 +27,18 @@ public class AsyncConfig implements AsyncConfigurer {
         return executor;
     }
 
+    @Bean("sendAlarm")
+    public Executor sendAlarmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(1000);
+        executor.setThreadNamePrefix("AlarmPush-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+        return executor;
+    }
+
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
         return new AsyncExceptionHandler();

--- a/src/main/java/apptive/team5/config/FcmConfig.java
+++ b/src/main/java/apptive/team5/config/FcmConfig.java
@@ -1,0 +1,53 @@
+package apptive.team5.config;
+
+import apptive.team5.global.exception.ExceptionCode;
+import apptive.team5.global.exception.ExternalApiConnectException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+import java.util.List;
+
+@Configuration
+@Slf4j
+public class FcmConfig {
+
+    @Value("${fcm.firebase.config.path}")
+    private String firebaseConfigPath;
+
+    @Bean
+    public GoogleCredentials googleCredentials() {
+        try {
+            GoogleCredentials googleCredentials = GoogleCredentials
+                    .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                    .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+            return googleCredentials;
+        } catch (IOException ex) {
+            log.error("Failed to load Firebase credentials from classpath: {}", firebaseConfigPath, ex);
+            throw new ExternalApiConnectException("firebase 연결 오류", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Bean
+    public FirebaseApp firebaseApp(GoogleCredentials googleCredentials) {
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(googleCredentials)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.initializeApp(options);
+        }
+        return FirebaseApp.getInstance();
+    }
+
+
+}

--- a/src/main/java/apptive/team5/diary/controller/DiaryLikeController.java
+++ b/src/main/java/apptive/team5/diary/controller/DiaryLikeController.java
@@ -30,7 +30,8 @@ public class DiaryLikeController {
             Long diaryId
     ) {
         DiaryLikeResponseDto responseDto = diaryLikeService.toggleDiaryLike(userId, diaryId);
-        alarmDispatchService.saveAndDispatchForLike(new AlarmSendRequest(
+
+        if (responseDto.isLiked()) alarmDispatchService.saveAndDispatchForLike(new AlarmSendRequest(
                 diaryId,
                 userId
         ));

--- a/src/main/java/apptive/team5/diary/controller/DiaryLikeController.java
+++ b/src/main/java/apptive/team5/diary/controller/DiaryLikeController.java
@@ -1,13 +1,14 @@
 package apptive.team5.diary.controller;
 
+import apptive.team5.alarm.dto.AlarmSendRequest;
+import apptive.team5.alarm.entity.AlarmMessage;
+import apptive.team5.alarm.service.AlarmDispatchService;
 import apptive.team5.diary.dto.DiaryLikeResponseDto;
 import apptive.team5.diary.service.DiaryLikeService;
-import apptive.team5.user.dto.UserResponse;
 import apptive.team5.user.dto.UserSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class DiaryLikeController {
 
     private final DiaryLikeService diaryLikeService;
+    private final AlarmDispatchService alarmDispatchService;
 
     @PostMapping
     public ResponseEntity<DiaryLikeResponseDto> toggleDiaryLike(
@@ -28,6 +30,10 @@ public class DiaryLikeController {
             Long diaryId
     ) {
         DiaryLikeResponseDto responseDto = diaryLikeService.toggleDiaryLike(userId, diaryId);
+        alarmDispatchService.saveAndDispatchForLike(new AlarmSendRequest(
+                diaryId,
+                userId
+        ));
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
+++ b/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
@@ -11,12 +11,16 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
 
     @Query("select d from DiaryEntity d where d.user = :user order by d.id desc")
     Page<DiaryEntity> findByUser(UserEntity user, Pageable pageable);
+
+    @Query("select d from DiaryEntity d join fetch d.user where d.id = :diaryId")
+    Optional<DiaryEntity> findByIdWithUser(Long diaryId);
 
     List<DiaryEntity> findByUserId(Long userId);
 

--- a/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
@@ -25,14 +25,11 @@ import java.util.stream.Collectors;
 @Transactional
 public class DiaryLikeService {
 
-    private static final String KILLING_PART_LIKE_TITLE = "킬링파트에 좋아요가 도착했어요";
-
     private final DiaryLikeLowService diaryLikeLowService;
     private final UserLowService userLowService;
     private final DiaryLowService diaryLowService;
     private final SubscribeLowService subscribeLowService;
     private final UserBlockLowService userBlockLowService;
-    private final AlarmDispatchService alarmDispatchService;
 
     public DiaryLikeResponseDto toggleDiaryLike(Long userId, Long diaryId) {
         UserEntity user = userLowService.getReferenceById(userId);
@@ -45,19 +42,8 @@ public class DiaryLikeService {
         }
         else {
             diaryLikeLowService.saveDiaryLike(new DiaryLikeEntity(user, diary));
-            sendKillingPartLikeAlarm(user, diary);
             return new DiaryLikeResponseDto(true);
         }
-    }
-
-    private void sendKillingPartLikeAlarm(UserEntity actor, DiaryEntity diary) {
-        UserEntity receiver = diary.getUser();
-
-        alarmDispatchService.saveAndDispatch(new AlarmSendRequest(
-                receiver,
-                KILLING_PART_LIKE_TITLE,
-                actor.getUsername() + "님이 회원님의 킬링파트를 좋아합니다."
-        ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
@@ -1,13 +1,12 @@
 package apptive.team5.diary.service;
 
+import apptive.team5.alarm.dto.AlarmSendRequest;
+import apptive.team5.alarm.service.AlarmDispatchService;
 import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryLikeEntity;
 import apptive.team5.diary.dto.DiaryLikeResponseDto;
-import apptive.team5.global.exception.DuplicateException;
-import apptive.team5.global.exception.ExceptionCode;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
-import apptive.team5.user.dto.UserResponse;
 import apptive.team5.user.dto.UserSearchResponse;
 import apptive.team5.user.service.UserBlockLowService;
 import apptive.team5.user.service.UserLowService;
@@ -25,11 +24,15 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional
 public class DiaryLikeService {
+
+    private static final String KILLING_PART_LIKE_TITLE = "킬링파트에 좋아요가 도착했어요";
+
     private final DiaryLikeLowService diaryLikeLowService;
     private final UserLowService userLowService;
     private final DiaryLowService diaryLowService;
     private final SubscribeLowService subscribeLowService;
     private final UserBlockLowService userBlockLowService;
+    private final AlarmDispatchService alarmDispatchService;
 
     public DiaryLikeResponseDto toggleDiaryLike(Long userId, Long diaryId) {
         UserEntity user = userLowService.getReferenceById(userId);
@@ -42,8 +45,19 @@ public class DiaryLikeService {
         }
         else {
             diaryLikeLowService.saveDiaryLike(new DiaryLikeEntity(user, diary));
+            sendKillingPartLikeAlarm(user, diary);
             return new DiaryLikeResponseDto(true);
         }
+    }
+
+    private void sendKillingPartLikeAlarm(UserEntity actor, DiaryEntity diary) {
+        UserEntity receiver = diary.getUser();
+
+        alarmDispatchService.saveAndDispatch(new AlarmSendRequest(
+                receiver,
+                KILLING_PART_LIKE_TITLE,
+                actor.getUsername() + "님이 회원님의 킬링파트를 좋아합니다."
+        ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/apptive/team5/diary/service/DiaryLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLowService.java
@@ -37,6 +37,12 @@ public class DiaryLowService {
     }
 
     @Transactional(readOnly = true)
+    public DiaryEntity findByIdWithUser(Long diaryId) {
+        return diaryRepository.findByIdWithUser(diaryId)
+                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.NOT_FOUND_DIARY.getDescription()));
+    }
+
+    @Transactional(readOnly = true)
     public Page<DiaryEntity> findDiaryByUser(UserEntity user, Pageable pageable) {
         return diaryRepository.findByUser(user, pageable);
     }

--- a/src/main/java/apptive/team5/fcm/controller/FcmController.java
+++ b/src/main/java/apptive/team5/fcm/controller/FcmController.java
@@ -1,0 +1,29 @@
+package apptive.team5.fcm.controller;
+
+import apptive.team5.fcm.dto.DeviceTokenRequest;
+import apptive.team5.fcm.service.FcmService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/tokens")
+    public ResponseEntity<Void> addToken(@Valid @RequestBody DeviceTokenRequest deviceTokenRequest,
+                                         @AuthenticationPrincipal Long userId){
+        fcmService.addDeviceToken(userId, deviceTokenRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/apptive/team5/fcm/dto/DeviceTokenRequest.java
+++ b/src/main/java/apptive/team5/fcm/dto/DeviceTokenRequest.java
@@ -1,0 +1,9 @@
+package apptive.team5.fcm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeviceTokenRequest(
+        @NotBlank
+        String token
+) {
+}

--- a/src/main/java/apptive/team5/fcm/entity/DeviceToken.java
+++ b/src/main/java/apptive/team5/fcm/entity/DeviceToken.java
@@ -1,0 +1,49 @@
+package apptive.team5.fcm.entity;
+
+import apptive.team5.global.entity.BaseTimeEntity;
+import apptive.team5.user.domain.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "device_token",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_device_token_token",
+                        columnNames = {"token"}
+                )
+        }
+)
+public class DeviceToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false
+    )
+    private UserEntity user;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String token;
+
+    public DeviceToken(UserEntity user, String token) {
+        this.user = user;
+        this.token = token;
+    }
+
+    public void updateMember(UserEntity member) {
+        this.user = member;
+    }
+
+}

--- a/src/main/java/apptive/team5/fcm/entity/DeviceToken.java
+++ b/src/main/java/apptive/team5/fcm/entity/DeviceToken.java
@@ -42,8 +42,8 @@ public class DeviceToken extends BaseTimeEntity {
         this.token = token;
     }
 
-    public void updateMember(UserEntity member) {
-        this.user = member;
+    public void updateUser(UserEntity user) {
+        this.user = user;
     }
 
 }

--- a/src/main/java/apptive/team5/fcm/repository/DeviceTokenRepository.java
+++ b/src/main/java/apptive/team5/fcm/repository/DeviceTokenRepository.java
@@ -1,0 +1,24 @@
+package apptive.team5.fcm.repository;
+
+import apptive.team5.fcm.entity.DeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from DeviceToken dt where dt.user.id = :userId")
+    void deleteByUserId(Long userId);
+
+    List<DeviceToken> findByUserId(Long userId);
+
+    Optional<DeviceToken> findByToken(String token);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from DeviceToken dt where dt.token = :token")
+    void deleteByToken(String token);
+}

--- a/src/main/java/apptive/team5/fcm/service/DeviceTokenLowService.java
+++ b/src/main/java/apptive/team5/fcm/service/DeviceTokenLowService.java
@@ -1,0 +1,40 @@
+package apptive.team5.fcm.service;
+
+
+import apptive.team5.fcm.entity.DeviceToken;
+import apptive.team5.fcm.repository.DeviceTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeviceTokenLowService {
+
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public DeviceToken save(DeviceToken deviceToken) {
+        return deviceTokenRepository.save(deviceToken);
+    }
+
+    public void deleteByUserId(Long userId) {
+        deviceTokenRepository.deleteByUserId(userId);
+    }
+
+    public List<DeviceToken> findByUserId(Long userId) {
+        return deviceTokenRepository.findByUserId(userId);
+    }
+
+    public Optional<DeviceToken> findByToken(String token) {
+        return deviceTokenRepository.findByToken(token);
+    }
+
+    public void deleteByToken(String token) {
+        deviceTokenRepository.deleteByToken(token);
+    }
+}

--- a/src/main/java/apptive/team5/fcm/service/FcmService.java
+++ b/src/main/java/apptive/team5/fcm/service/FcmService.java
@@ -29,7 +29,7 @@ public class FcmService {
 
 
         if (deviceToken.isPresent()) {
-            deviceToken.get().updateMember(user);
+            deviceToken.get().updateUser(user);
             return deviceToken.get();
         }
 
@@ -37,13 +37,13 @@ public class FcmService {
     }
 
     @Async("sendAlarm")
-    public void sendArticleAlarm(Long memberId, String articleTitle, String articleComment) {
+    public void sendAlarm(Long userId, String title, String content) {
 
-        List<DeviceToken> deviceTokens = deviceTokenLowService.findByUserId(memberId);
+        List<DeviceToken> deviceTokens = deviceTokenLowService.findByUserId(userId);
 
 
         deviceTokens.forEach(deviceToken -> {
-            sendMessageTo(deviceToken.getToken(), articleTitle, articleComment);
+            sendMessageTo(deviceToken.getToken(), title, content);
         });
 
     }

--- a/src/main/java/apptive/team5/fcm/service/FcmService.java
+++ b/src/main/java/apptive/team5/fcm/service/FcmService.java
@@ -40,12 +40,11 @@ public class FcmService {
     public void sendAlarm(Long userId, String title, String content, String deepLink) {
 
         List<DeviceToken> deviceTokens = deviceTokenLowService.findByUserId(userId);
+        if (deviceTokens.isEmpty()) {
+            return;
+        }
 
-
-        deviceTokens.forEach(deviceToken -> {
-            sendMessageTo(deviceToken.getToken(), title, content, deepLink);
-        });
-
+        deviceTokens.forEach(deviceToken -> sendMessageTo(deviceToken.getToken(), title, content, deepLink));
     }
 
     private void sendMessageTo(String targetToken, String title, String body, String deepLink) {
@@ -64,18 +63,23 @@ public class FcmService {
         FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
 
         ApiFuture<String> future = firebaseMessaging.sendAsync(message);
+        future.addListener(() -> handleSendResult(future, targetToken), Runnable::run);
+    }
 
-        future.addListener(() -> {
-            try {
-                future.get();
-            } catch (Exception ex) {
-                Throwable cause = ex.getCause();
-                if (cause instanceof FirebaseMessagingException fme) {
-                    if (fme.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
-                        deviceTokenLowService.deleteByToken(targetToken);
-                    }
-                }
+    private void handleSendResult(ApiFuture<String> future, String targetToken) {
+        try {
+            future.get();
+            return;
+        } catch (Exception ex) {
+            Throwable cause = ex.getCause();
+            if (!(cause instanceof FirebaseMessagingException fme)) {
+                return;
             }
-        }, Runnable::run);
+            if (fme.getMessagingErrorCode() != MessagingErrorCode.UNREGISTERED) {
+                return;
+            }
+        }
+
+        deviceTokenLowService.deleteByToken(targetToken);
     }
 }

--- a/src/main/java/apptive/team5/fcm/service/FcmService.java
+++ b/src/main/java/apptive/team5/fcm/service/FcmService.java
@@ -1,0 +1,80 @@
+package apptive.team5.fcm.service;
+
+import apptive.team5.fcm.dto.DeviceTokenRequest;
+import apptive.team5.fcm.entity.DeviceToken;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final DeviceTokenLowService deviceTokenLowService;
+    private final UserLowService userLowService;
+
+    public DeviceToken addDeviceToken(Long userId, DeviceTokenRequest deviceTokenRequest) {
+        Optional<DeviceToken> deviceToken = deviceTokenLowService.findByToken(deviceTokenRequest.token());
+
+        UserEntity user = userLowService.findById(userId);
+
+
+        if (deviceToken.isPresent()) {
+            deviceToken.get().updateMember(user);
+            return deviceToken.get();
+        }
+
+        return deviceTokenLowService.save(new DeviceToken(user, deviceTokenRequest.token()));
+    }
+
+    @Async("sendAlarm")
+    public void sendArticleAlarm(Long memberId, String articleTitle, String articleComment) {
+
+        List<DeviceToken> deviceTokens = deviceTokenLowService.findByUserId(memberId);
+
+
+        deviceTokens.forEach(deviceToken -> {
+            sendMessageTo(deviceToken.getToken(), articleTitle, articleComment);
+        });
+
+    }
+
+    private void sendMessageTo(String targetToken, String title, String body) {
+
+        Message message = Message.builder()
+                .setToken(targetToken)
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build()
+                )
+                .build();
+
+        FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
+
+        ApiFuture<String> future = firebaseMessaging.sendAsync(message);
+
+        future.addListener(() -> {
+            try {
+                future.get();
+            } catch (Exception ex) {
+                Throwable cause = ex.getCause();
+                if (cause instanceof FirebaseMessagingException fme) {
+                    if (fme.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+                        deviceTokenLowService.deleteByToken(targetToken);
+                    }
+                }
+            }
+        }, Runnable::run);
+    }
+}

--- a/src/main/java/apptive/team5/fcm/service/FcmService.java
+++ b/src/main/java/apptive/team5/fcm/service/FcmService.java
@@ -37,18 +37,18 @@ public class FcmService {
     }
 
     @Async("sendAlarm")
-    public void sendAlarm(Long userId, String title, String content) {
+    public void sendAlarm(Long userId, String title, String content, String deepLink) {
 
         List<DeviceToken> deviceTokens = deviceTokenLowService.findByUserId(userId);
 
 
         deviceTokens.forEach(deviceToken -> {
-            sendMessageTo(deviceToken.getToken(), title, content);
+            sendMessageTo(deviceToken.getToken(), title, content, deepLink);
         });
 
     }
 
-    private void sendMessageTo(String targetToken, String title, String body) {
+    private void sendMessageTo(String targetToken, String title, String body, String deepLink) {
 
         Message message = Message.builder()
                 .setToken(targetToken)
@@ -58,6 +58,7 @@ public class FcmService {
                                 .setBody(body)
                                 .build()
                 )
+                .putData("deepLink", deepLink)
                 .build();
 
         FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();

--- a/src/main/java/apptive/team5/user/service/UserService.java
+++ b/src/main/java/apptive/team5/user/service/UserService.java
@@ -1,5 +1,7 @@
 package apptive.team5.user.service;
+import apptive.team5.alarm.service.AlarmLowService;
 import apptive.team5.diary.service.*;
+import apptive.team5.fcm.service.DeviceTokenLowService;
 import apptive.team5.file.dto.FileUploadRequest;
 import apptive.team5.file.service.S3Service;
 import apptive.team5.file.service.TemporalLowService;
@@ -56,6 +58,8 @@ public class UserService {
     private final UserInitSettingService userInitSettingService;
     private final UserPolicyLowService userPolicyLowService;
     private final UserBlockLowService userBlockLowService;
+    private final DeviceTokenLowService deviceTokenLowService;
+    private final AlarmLowService alarmLowService;
 
     public TokenResponse socialLogin(OAuth2Response oAuth2Response) {
         String identifier = oAuth2Response.getProvider() + "-" +oAuth2Response.getProviderId();
@@ -100,6 +104,8 @@ public class UserService {
             appleRefreshTokenLowService.deleteByUserId(userId);
         }
 
+        alarmLowService.deleteByUserId(userId);
+        deviceTokenLowService.deleteByUserId(userId);
         surveyLowService.deleteByUserId(userId);
         subscribeLowService.deleteByUserId(userId);
         diaryStoreLowService.deleteByUserId(userId);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,4 @@ apple.clientId=${APPLE_CLIENT_ID}
 apple.teamId=${APPLE_TEAM_ID}
 apple.privateKey=${APPLE_PRIVATE_KEY}
 apple.keyId=${APPLE_KEY_ID}
+fcm.firebase.config.path=${FIREBASE_KEY}

--- a/src/test/java/apptive/team5/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/apptive/team5/alarm/controller/AlarmControllerTest.java
@@ -1,0 +1,91 @@
+package apptive.team5.alarm.controller;
+
+import apptive.team5.alarm.dto.AlarmResponse;
+import apptive.team5.alarm.entity.Alarm;
+import apptive.team5.alarm.repository.AlarmRepository;
+import apptive.team5.global.exception.ExceptionCode;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.domain.UserRoleType;
+import apptive.team5.user.repository.UserRepository;
+import apptive.team5.util.TestSecurityContextHolderInjection;
+import apptive.team5.util.TestUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.securityContext;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AlarmControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AlarmRepository alarmRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("내 알림 목록 조회 성공")
+    @Test
+    void getAlarmsSuccess() throws Exception {
+
+        // given
+        UserEntity user = userRepository.save(TestUtil.makeUserEntity());
+        UserEntity otherUser = userRepository.save(TestUtil.makeDifferentUserEntity(user));
+
+        alarmRepository.save(new Alarm("first title", "first content", user));
+        Alarm secondAlarm = alarmRepository.save(new Alarm("second title", "second content", user));
+        alarmRepository.save(new Alarm("other title", "other content", otherUser));
+
+        TestSecurityContextHolderInjection.inject(user.getId(), user.getRoleType());
+
+        // when
+        String response = mockMvc.perform(get("/api/alarms")
+                        .param("page", "0")
+                        .param("size", "1")
+                        .with(securityContext(SecurityContextHolder.getContext()))
+                )
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(UTF_8);
+
+        // then
+        JsonNode jsonNode = objectMapper.readTree(response);
+        List<AlarmResponse> content = objectMapper.convertValue(
+                jsonNode.path("content"),
+                new TypeReference<List<AlarmResponse>>() {}
+        );
+
+        assertSoftly(softly -> {
+            softly.assertThat(content).hasSize(1);
+            softly.assertThat(content.getFirst().alarmId()).isEqualTo(secondAlarm.getId());
+            softly.assertThat(content.getFirst().title()).isEqualTo(secondAlarm.getTitle());
+            softly.assertThat(content.getFirst().content()).isEqualTo(secondAlarm.getContent());
+            softly.assertThat(jsonNode.path("page").path("totalElements").asInt()).isEqualTo(2);
+            softly.assertThat(jsonNode.path("page").path("size").asInt()).isEqualTo(1);
+            softly.assertThat(jsonNode.path("page").path("number").asInt()).isEqualTo(0);
+        });
+    }
+}

--- a/src/test/java/apptive/team5/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/apptive/team5/alarm/controller/AlarmControllerTest.java
@@ -56,9 +56,9 @@ class AlarmControllerTest {
         UserEntity user = userRepository.save(TestUtil.makeUserEntity());
         UserEntity otherUser = userRepository.save(TestUtil.makeDifferentUserEntity(user));
 
-        alarmRepository.save(new Alarm("first title", "first content", user));
-        Alarm secondAlarm = alarmRepository.save(new Alarm("second title", "second content", user));
-        alarmRepository.save(new Alarm("other title", "other content", otherUser));
+        alarmRepository.save(new Alarm("first title", "first content", "/diaries/1", user));
+        Alarm secondAlarm = alarmRepository.save(new Alarm("second title", "second content", "/diaries/2", user));
+        alarmRepository.save(new Alarm("other title", "other content", "/diaries/3", otherUser));
 
         TestSecurityContextHolderInjection.inject(user.getId(), user.getRoleType());
 
@@ -83,6 +83,7 @@ class AlarmControllerTest {
             softly.assertThat(content.getFirst().alarmId()).isEqualTo(secondAlarm.getId());
             softly.assertThat(content.getFirst().title()).isEqualTo(secondAlarm.getTitle());
             softly.assertThat(content.getFirst().content()).isEqualTo(secondAlarm.getContent());
+            softly.assertThat(content.getFirst().deepLink()).isEqualTo(secondAlarm.getDeepLink());
             softly.assertThat(jsonNode.path("page").path("totalElements").asInt()).isEqualTo(2);
             softly.assertThat(jsonNode.path("page").path("size").asInt()).isEqualTo(1);
             softly.assertThat(jsonNode.path("page").path("number").asInt()).isEqualTo(0);

--- a/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
@@ -69,7 +69,6 @@ class DiaryLikeServiceTest {
         verify(diaryLowService).findDiaryById(diaryId);
         verify(diaryLikeLowService).existsByUserAndDiary(user, diary);
         verify(diaryLikeLowService).saveDiaryLike(any(DiaryLikeEntity.class));
-        verify(alarmDispatchService).saveAndDispatch(any());
         verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService, alarmDispatchService);
     }
 

--- a/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
@@ -1,7 +1,9 @@
 package apptive.team5.diary.service;
 
+import apptive.team5.alarm.service.AlarmDispatchService;
 import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryLikeEntity;
+import apptive.team5.diary.domain.DiaryScope;
 import apptive.team5.diary.dto.DiaryLikeResponseDto;
 import apptive.team5.global.exception.DuplicateException;
 import apptive.team5.global.exception.NotFoundEntityException;
@@ -20,6 +22,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,12 +40,16 @@ class DiaryLikeServiceTest {
     @Mock
     private DiaryLowService diaryLowService;
 
+    @Mock
+    private AlarmDispatchService alarmDispatchService;
+
     @Test
     @DisplayName("좋아요 토글 - 좋아요 없을 때")
     void toggleDiaryLike_add() {
         // given
         UserEntity user = TestUtil.makeUserEntityWithId();
-        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        UserEntity diaryOwner = new UserEntity(2L, "owner-1", "owner@gmail.com", "owner", "ownerTag", user.getRoleType(), user.getSocialType());
+        DiaryEntity diary = TestUtil.makeDiaryEntityWithScope(diaryOwner, DiaryScope.KILLING_PART);
         Long userId = user.getId();
         Long diaryId = 1L;
 
@@ -62,7 +69,8 @@ class DiaryLikeServiceTest {
         verify(diaryLowService).findDiaryById(diaryId);
         verify(diaryLikeLowService).existsByUserAndDiary(user, diary);
         verify(diaryLikeLowService).saveDiaryLike(any(DiaryLikeEntity.class));
-        verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService);
+        verify(alarmDispatchService).saveAndDispatch(any());
+        verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService, alarmDispatchService);
     }
 
     @Test
@@ -94,6 +102,7 @@ class DiaryLikeServiceTest {
         verify(diaryLikeLowService).existsByUserAndDiary(user, diary);
         verify(diaryLikeLowService).findByUserAndDiary(user, diary);
         verify(diaryLikeLowService).deleteDiaryLike(diaryLike);
+        verifyNoInteractions(alarmDispatchService);
         verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -57,3 +57,4 @@ apple.clientId=${APPLE_CLIENT_ID}
 apple.teamId=${APPLE_TEAM_ID}
 apple.privateKey=${APPLE_PRIVATE_KEY}
 apple.keyId=${APPLE_KEY_ID}
+fcm.firebase.config.path=${FIREBASE_KEY}


### PR DESCRIPTION
# 변경점 👍
알람 기능을 구현했습니다.

`firebase`를 통한 알람 기능을 구현했습니다. (먼저 킬링파트 좋아요에만 알람 리스너 추가해놨습니다. 먼저 알람 정상 확인하고 추후 확장예정)
알람을 보내기 위해서는 클라이언트에서 발급한 디바이스 토큰을 `POST /api/fcm/tokens` 엔드포인트를 호출해서 저장해야합니다.

`Alarm` 엔티티는 단순히 DB에 저장하기 위한 용도입니다. 

알람 구현에는 `ApplicationEventPublisher`와 `TransactionalEventListener`를 사용해봤습니다.

특정 클래스를 `ApplicationEventPublisher`로 이벤트를 publish하면 `TransactionalEventListener`가 동작합니다.





