### PR TITLE
Feat/59 tag search

### DIFF
--- a/src/main/java/apptive/team5/booth/controller/BoothController.java
+++ b/src/main/java/apptive/team5/booth/controller/BoothController.java
@@ -1,0 +1,45 @@
+package apptive.team5.booth.controller;
+
+import apptive.team5.booth.dto.PublicKillingPartResponse;
+import apptive.team5.booth.dto.PublicUserResponse;
+import apptive.team5.booth.service.BoothService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/public")
+@RequiredArgsConstructor
+public class BoothController {
+
+    private final BoothService boothService;
+
+    @GetMapping("/users/search")
+    public ResponseEntity<PublicUserResponse> findUserByTag(@RequestParam String tag) {
+        PublicUserResponse response = boothService.findUserByTag(tag);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/users/{userId}/playlist")
+    public ResponseEntity<Page<PublicKillingPartResponse>> getUserPlaylist(
+            @PathVariable
+            Long userId,
+            @RequestParam(defaultValue = "0")
+            int page,
+            @RequestParam(defaultValue = "5")
+            int size
+    ) {
+        Page<PublicKillingPartResponse> response =
+                boothService.getUserPlaylist(userId, PageRequest.of(page, size));
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/apptive/team5/booth/dto/PublicKillingPartResponse.java
+++ b/src/main/java/apptive/team5/booth/dto/PublicKillingPartResponse.java
@@ -1,0 +1,27 @@
+package apptive.team5.booth.dto;
+
+import apptive.team5.diary.domain.DiaryEntity;
+
+public record PublicKillingPartResponse(
+        Long diaryId,
+        String artist,
+        String musicTitle,
+        String albumImageUrl,
+        String videoUrl,
+        String totalDuration,
+        String start,
+        String end
+) {
+    public static PublicKillingPartResponse from(DiaryEntity diary) {
+        return new PublicKillingPartResponse(
+                diary.getId(),
+                diary.getArtist(),
+                diary.getMusicTitle(),
+                diary.getAlbumImageUrl(),
+                diary.getVideoUrl(),
+                diary.getTotalDuration(),
+                diary.getStart(),
+                diary.getEnd()
+        );
+    }
+}

--- a/src/main/java/apptive/team5/booth/dto/PublicUserResponse.java
+++ b/src/main/java/apptive/team5/booth/dto/PublicUserResponse.java
@@ -1,0 +1,20 @@
+package apptive.team5.booth.dto;
+
+import apptive.team5.global.util.S3Util;
+import apptive.team5.user.domain.UserEntity;
+
+public record PublicUserResponse(
+        Long userId,
+        String username,
+        String tag,
+        String profileImageUrl
+) {
+    public static PublicUserResponse from(UserEntity user) {
+        return new PublicUserResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getTag(),
+                S3Util.s3Url + user.getProfileImage()
+        );
+    }
+}

--- a/src/main/java/apptive/team5/booth/service/BoothService.java
+++ b/src/main/java/apptive/team5/booth/service/BoothService.java
@@ -1,0 +1,42 @@
+package apptive.team5.booth.service;
+
+import apptive.team5.booth.dto.PublicKillingPartResponse;
+import apptive.team5.booth.dto.PublicUserResponse;
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.domain.DiaryScope;
+import apptive.team5.diary.service.DiaryLowService;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class BoothService {
+
+    private final UserLowService userLowService;
+    private final DiaryLowService diaryLowService;
+
+    private static final List<DiaryScope> VISIBLE_SCOPES =
+            List.of(DiaryScope.PUBLIC, DiaryScope.KILLING_PART);
+
+    @Transactional(readOnly = true)
+    public PublicUserResponse findUserByTag(String tag) {
+        UserEntity user = userLowService.findByTag(tag);
+        return PublicUserResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PublicKillingPartResponse> getUserPlaylist(Long userId, Pageable pageable) {
+        Page<DiaryEntity> diaryPage =
+                diaryLowService.findDiaryByUserAndScopeIn(userId, VISIBLE_SCOPES, pageable);
+
+        return diaryPage.map(PublicKillingPartResponse::from);
+    }
+}

--- a/src/main/java/apptive/team5/config/SecurityConfig.java
+++ b/src/main/java/apptive/team5/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
     private final String[] whiteList =
             {
                     "/api/jwt/exchange",
-                    "/api/oauth2/**"
+                    "/api/oauth2/**",
+                    "/api/public/**"
             };
 }

--- a/src/main/java/apptive/team5/user/service/UserLowService.java
+++ b/src/main/java/apptive/team5/user/service/UserLowService.java
@@ -57,6 +57,12 @@ public class UserLowService {
     }
 
     @Transactional(readOnly = true)
+    public UserEntity findByTag(String tag) {
+        return userRepository.findByTag(tag)
+                .orElseThrow(() -> new NotFoundEntityException(ExceptionCode.NOT_FOUND_USER.getDescription()));
+    }
+
+    @Transactional(readOnly = true)
     public Page<UserEntity> findByTagOrUsernameExcludingBlocked(Set<Long> blockedUserIds, String searchCond, Pageable pageable) {
         return qUserRepository.findByTagOrUsernameExcludingBlocked(blockedUserIds, searchCond,pageable);
     }

--- a/src/test/java/apptive/team5/booth/service/BoothServiceTest.java
+++ b/src/test/java/apptive/team5/booth/service/BoothServiceTest.java
@@ -1,0 +1,141 @@
+package apptive.team5.booth.service;
+
+import apptive.team5.booth.dto.PublicKillingPartResponse;
+import apptive.team5.booth.dto.PublicUserResponse;
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.domain.DiaryScope;
+import apptive.team5.diary.service.DiaryLowService;
+import apptive.team5.global.exception.NotFoundEntityException;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import apptive.team5.util.TestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class BoothServiceTest {
+
+    @InjectMocks
+    private BoothService boothService;
+
+    @Mock
+    private UserLowService userLowService;
+
+    @Mock
+    private DiaryLowService diaryLowService;
+
+    @Test
+    @DisplayName("태그로 유저 조회 - 성공")
+    void findUserByTag_success() {
+        // given
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        String tag = user.getTag();
+
+        given(userLowService.findByTag(tag)).willReturn(user);
+
+        // when
+        PublicUserResponse response = boothService.findUserByTag(tag);
+
+        // then
+        assertThat(response.userId()).isEqualTo(user.getId());
+        assertThat(response.username()).isEqualTo(user.getUsername());
+        assertThat(response.tag()).isEqualTo(tag);
+        assertThat(response.profileImageUrl()).contains(user.getProfileImage());
+
+        verify(userLowService).findByTag(tag);
+        verifyNoMoreInteractions(userLowService, diaryLowService);
+    }
+
+    @Test
+    @DisplayName("태그로 유저 조회 - 태그 없으면 NotFoundEntityException")
+    void findUserByTag_notFound() {
+        // given
+        String tag = "MISSING_TAG";
+        given(userLowService.findByTag(tag))
+                .willThrow(new NotFoundEntityException("존재하지 않는 회원입니다."));
+
+        // when / then
+        assertThatThrownBy(() -> boothService.findUserByTag(tag))
+                .isInstanceOf(NotFoundEntityException.class);
+
+        verify(userLowService).findByTag(tag);
+        verifyNoMoreInteractions(userLowService, diaryLowService);
+    }
+
+    @Test
+    @DisplayName("플레이리스트 조회 - PUBLIC/KILLING_PART 스코프 필터로 호출")
+    void getUserPlaylist_filtersScopes() {
+        // given
+        UserEntity owner = TestUtil.makeUserEntityWithId();
+        Long userId = owner.getId();
+
+        DiaryEntity publicDiary = TestUtil.makeDiaryEntityWithScope(owner, DiaryScope.PUBLIC);
+        ReflectionTestUtils.setField(publicDiary, "id", 10L);
+        DiaryEntity killingPartDiary = TestUtil.makeDiaryEntityWithScope(owner, DiaryScope.KILLING_PART);
+        ReflectionTestUtils.setField(killingPartDiary, "id", 11L);
+
+        Page<DiaryEntity> diaryPage = new PageImpl<>(List.of(publicDiary, killingPartDiary));
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        List<DiaryScope> visibleScopes = List.of(DiaryScope.PUBLIC, DiaryScope.KILLING_PART);
+
+        given(diaryLowService.findDiaryByUserAndScopeIn(userId, visibleScopes, pageRequest))
+                .willReturn(diaryPage);
+
+        // when
+        Page<PublicKillingPartResponse> result = boothService.getUserPlaylist(userId, pageRequest);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+
+        PublicKillingPartResponse publicDto = result.getContent().get(0);
+        assertThat(publicDto.diaryId()).isEqualTo(10L);
+        assertThat(publicDto.musicTitle()).isEqualTo("Test Music");
+        assertThat(publicDto.artist()).isEqualTo("Test Artist");
+        assertThat(publicDto.albumImageUrl()).isEqualTo("image.url");
+        assertThat(publicDto.videoUrl()).isEqualTo("video.url");
+        assertThat(publicDto.totalDuration()).isEqualTo("PT2M58S");
+        assertThat(publicDto.start()).isEqualTo("PT1M1S");
+        assertThat(publicDto.end()).isEqualTo("PT1M31S");
+
+        PublicKillingPartResponse killingPartDto = result.getContent().get(1);
+        assertThat(killingPartDto.diaryId()).isEqualTo(11L);
+
+        verify(diaryLowService).findDiaryByUserAndScopeIn(userId, visibleScopes, pageRequest);
+        verifyNoMoreInteractions(userLowService, diaryLowService);
+    }
+
+    @Test
+    @DisplayName("플레이리스트 조회 - 다이어리 없으면 빈 페이지")
+    void getUserPlaylist_emptyResult() {
+        // given
+        Long userId = 999L;
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        List<DiaryScope> visibleScopes = List.of(DiaryScope.PUBLIC, DiaryScope.KILLING_PART);
+
+        given(diaryLowService.findDiaryByUserAndScopeIn(userId, visibleScopes, pageRequest))
+                .willReturn(new PageImpl<>(List.of()));
+
+        // when
+        Page<PublicKillingPartResponse> result = boothService.getUserPlaylist(userId, pageRequest);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        verify(diaryLowService).findDiaryByUserAndScopeIn(userId, visibleScopes, pageRequest);
+    }
+}


### PR DESCRIPTION
# 변경점 👍

- 토큰 없이 태그 기반 조회를 위한 임시 api 두 개 추가했습니다.
- 태그로 유저 조회
- 유저 킬링파트 플레이리스트 조회 

# 비고 ✏

- 미사용 시점에 booth 패키지 통째로 삭제하고 whiteList에서 booth 제거하면 됩니다.

