### PR TITLE
탐색 탭 추천 로직 구현

### DIFF
--- a/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
+++ b/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
@@ -125,6 +125,10 @@ public class DiaryEntity extends BaseTimeEntity {
         updateMusicPlayInfo(info.musicPlayInfo());
     }
 
+    public void assignMusicMetadata(MusicMetadataEntity musicMetadata) {
+        this.musicMetadata = musicMetadata;
+    }
+
     public void updateMusicBaseInfo(MusicBasicInfo musicBasicInfo) {
         updateMusicTitle(musicBasicInfo.musicTitle());
         updateArtist(musicBasicInfo.artist());

--- a/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
+++ b/src/main/java/apptive/team5/diary/domain/DiaryEntity.java
@@ -6,8 +6,9 @@ import apptive.team5.diary.domain.model.MusicPlayInfo;
 import apptive.team5.global.entity.BaseTimeEntity;
 import apptive.team5.global.exception.BadRequestException;
 import apptive.team5.global.exception.ExceptionCode;
-import apptive.team5.user.domain.UserEntity;
 import apptive.team5.diary.domain.model.MusicBasicInfo;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.user.domain.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -73,6 +74,10 @@ public class DiaryEntity extends BaseTimeEntity {
             nullable = false
     )
     private UserEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "music_metadata_id")
+    private MusicMetadataEntity musicMetadata;
 
     private static final String HIDDEN_CONTENT_DEFAULT_MESSAGE = "비공개 일기입니다.";
 

--- a/src/main/java/apptive/team5/diary/dto/DiaryCreateRequest.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryCreateRequest.java
@@ -30,31 +30,32 @@ public record DiaryCreateRequest(
         @NotBlank(message = "킬링파트 시작 시간은 필수 입력입니다.")
         String start,
         @NotBlank(message = "킬링파트 종료 시간은 필수 입력입니다.")
-        String end
+        String end,
+        DiaryMusicMetadataRequest musicMetadata
 ) {
-        public DiaryEntity toEntity(UserEntity user) {
-                DiaryInfo diaryInfo = new DiaryInfo(
-                        new MusicBasicInfo(
-                                musicTitle,
-                                artist,
-                                albumImageUrl,
-                                videoUrl
-                        ),
-                        new DiaryBasicInfo(
-                                content,
-                                scope
-                        ),
-                        new MusicPlayInfo(
-                                duration,
-                                totalDuration,
-                                start,
-                                end
-                        )
-                );
+    public DiaryEntity toEntity(UserEntity user) {
+        DiaryInfo diaryInfo = new DiaryInfo(
+                new MusicBasicInfo(
+                        musicTitle,
+                        artist,
+                        albumImageUrl,
+                        videoUrl
+                ),
+                new DiaryBasicInfo(
+                        content,
+                        scope
+                ),
+                new MusicPlayInfo(
+                        duration,
+                        totalDuration,
+                        start,
+                        end
+                )
+        );
 
-                return new DiaryEntity(
-                        diaryInfo,
-                        user
-                );
-        }
+        return new DiaryEntity(
+                diaryInfo,
+                user
+        );
+    }
 }

--- a/src/main/java/apptive/team5/diary/dto/DiaryMusicMetadataRequest.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryMusicMetadataRequest.java
@@ -1,0 +1,14 @@
+package apptive.team5.diary.dto;
+
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+
+public record DiaryMusicMetadataRequest(
+        MusicMetadataSourceType sourceType,
+        String trackId,
+        String artistId,
+        String primaryGenreName
+) {
+    public boolean hasTrackId() {
+        return sourceType != null && trackId != null && !trackId.isBlank();
+    }
+}

--- a/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequestDto.java
+++ b/src/main/java/apptive/team5/diary/dto/DiaryUpdateRequestDto.java
@@ -16,7 +16,8 @@ public record DiaryUpdateRequestDto(
         String duration,
         String totalDuration,
         String start,
-        String end
+        String end,
+        DiaryMusicMetadataRequest musicMetadata
 ) {
     public DiaryInfo toDomainInfo() {
         return new DiaryInfo(

--- a/src/main/java/apptive/team5/diary/dto/FeedDiaryResponseDto.java
+++ b/src/main/java/apptive/team5/diary/dto/FeedDiaryResponseDto.java
@@ -30,9 +30,23 @@ public record FeedDiaryResponseDto (
         Long userId,
         String username,
         String tag,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean isRecommended,
+        String recommendationReason
 ) implements DiaryResponseDto {
     public static FeedDiaryResponseDto from(DiaryEntity diary, boolean isLiked, boolean isStored, Long likeCount, Long currentUserId) {
+        return from(diary, isLiked, isStored, likeCount, currentUserId, false, null);
+    }
+
+    public static FeedDiaryResponseDto from(
+            DiaryEntity diary,
+            boolean isLiked,
+            boolean isStored,
+            Long likeCount,
+            Long currentUserId,
+            boolean isRecommended,
+            String recommendationReason
+    ) {
         String contentResponse = diary.getContentForViewer(currentUserId);
         UserEntity user = diary.getUser();
 
@@ -56,7 +70,9 @@ public record FeedDiaryResponseDto (
                 user.getId(),
                 user.getUsername(),
                 user.getTag(),
-                S3Util.s3Url + user.getProfileImage()
+                S3Util.s3Url + user.getProfileImage(),
+                isRecommended,
+                recommendationReason
         );
     }
 }

--- a/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
+++ b/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
@@ -49,6 +49,22 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
     @Query("select d from DiaryEntity d join fetch d.user where d.user.id in :userIds and d.scope in :scopes order by d.id desc")
     Page<DiaryEntity> findByUserIdsAndScopseWithUserPage(Set<Long> userIds, List<DiaryScope> scopes, Pageable pageable);
 
+    @Query("""
+            select d from DiaryEntity d
+            join fetch d.user
+            left join fetch d.musicMetadata
+            where d.user.id not in :excludedUserIds
+              and d.scope in :scopes
+              and d.createDateTime >= :startDateTime
+            order by d.createDateTime desc, d.id desc
+            """)
+    List<DiaryEntity> findRecentExploreCandidates(
+            Set<Long> excludedUserIds,
+            List<DiaryScope> scopes,
+            LocalDateTime startDateTime,
+            Pageable pageable
+    );
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from DiaryEntity d where d.id in :diaryIds")
     void deleteByIds(List<Long> diaryIds);

--- a/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
+++ b/src/main/java/apptive/team5/diary/repository/DiaryRepository.java
@@ -65,6 +65,20 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
             Pageable pageable
     );
 
+    @Query("""
+            select d from DiaryEntity d
+            join fetch d.user
+            left join fetch d.musicMetadata
+            where d.user.id not in :excludedUserIds
+              and d.scope in :scopes
+            order by d.createDateTime desc, d.id desc
+            """)
+    List<DiaryEntity> findExploreCandidates(
+            Set<Long> excludedUserIds,
+            List<DiaryScope> scopes,
+            Pageable pageable
+    );
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from DiaryEntity d where d.id in :diaryIds")
     void deleteByIds(List<Long> diaryIds);

--- a/src/main/java/apptive/team5/diary/service/DiaryLikeLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLikeLowService.java
@@ -48,6 +48,9 @@ public class DiaryLikeLowService {
 
     @Transactional(readOnly = true)
     public Set<Long> findLikedDiaryIdsByUser(Long currentUserId, List<Long> diaryIds) {
+        if (diaryIds == null || diaryIds.isEmpty()) {
+            return Set.of();
+        }
         return diaryLikeRepository.findLikedDiaryIdsByUser(currentUserId, diaryIds);
     }
 

--- a/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLikeService.java
@@ -3,6 +3,7 @@ package apptive.team5.diary.service;
 import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryLikeEntity;
 import apptive.team5.diary.dto.DiaryLikeResponseDto;
+import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.dto.UserSearchResponse;
@@ -28,6 +29,7 @@ public class DiaryLikeService {
     private final DiaryLowService diaryLowService;
     private final SubscribeLowService subscribeLowService;
     private final UserBlockLowService userBlockLowService;
+    private final PreferenceService preferenceService;
 
     public DiaryLikeResponseDto toggleDiaryLike(Long userId, Long diaryId) {
         UserEntity user = userLowService.getReferenceById(userId);
@@ -36,10 +38,12 @@ public class DiaryLikeService {
         if (diaryLikeLowService.existsByUserAndDiary(user, diary)) {
             DiaryLikeEntity diaryLike = diaryLikeLowService.findByUserAndDiary(user, diary);
             diaryLikeLowService.deleteDiaryLike(diaryLike);
+            preferenceService.reflectDiaryLikeRemoved(user, diary);
             return new DiaryLikeResponseDto(false);
         }
         else {
             diaryLikeLowService.saveDiaryLike(new DiaryLikeEntity(user, diary));
+            preferenceService.reflectDiaryLiked(user, diary);
             return new DiaryLikeResponseDto(true);
         }
     }

--- a/src/main/java/apptive/team5/diary/service/DiaryLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLowService.java
@@ -63,6 +63,16 @@ public class DiaryLowService {
     }
 
     @Transactional(readOnly = true)
+    public List<DiaryEntity> findRecentExploreCandidates(
+            Set<Long> excludedUserIds,
+            List<DiaryScope> scopes,
+            LocalDateTime startDateTime,
+            Pageable pageable
+    ) {
+        return diaryRepository.findRecentExploreCandidates(excludedUserIds, scopes, startDateTime, pageable);
+    }
+
+    @Transactional(readOnly = true)
     public List<DiaryEntity> findByUserIdAndPeriod(Long userId, LocalDateTime start, LocalDateTime end) {
         return diaryRepository.findByUserIdAndCreateDateTimeBetween(userId, start, end);
     }

--- a/src/main/java/apptive/team5/diary/service/DiaryLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryLowService.java
@@ -73,6 +73,15 @@ public class DiaryLowService {
     }
 
     @Transactional(readOnly = true)
+    public List<DiaryEntity> findExploreCandidates(
+            Set<Long> excludedUserIds,
+            List<DiaryScope> scopes,
+            Pageable pageable
+    ) {
+        return diaryRepository.findExploreCandidates(excludedUserIds, scopes, pageable);
+    }
+
+    @Transactional(readOnly = true)
     public List<DiaryEntity> findByUserIdAndPeriod(Long userId, LocalDateTime start, LocalDateTime end) {
         return diaryRepository.findByUserIdAndCreateDateTimeBetween(userId, start, end);
     }

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -8,6 +8,7 @@ import apptive.team5.diary.mapper.DiaryResponseMapper;
 import apptive.team5.recommendation.domain.MusicMetadataEntity;
 import apptive.team5.recommendation.service.MusicMetadataService;
 import apptive.team5.recommendation.service.PreferenceService;
+import apptive.team5.recommendation.service.RecommendationService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.service.UserBlockLowService;
@@ -44,6 +45,7 @@ public class DiaryService {
     private final UserBlockLowService userBlockLowService;
     private final MusicMetadataService musicMetadataService;
     private final PreferenceService preferenceService;
+    private final RecommendationService recommendationService;
 
     @Transactional(readOnly = true)
     public Page<MyDiaryResponseDto> getMyDiaries(Long userId, Pageable pageable) {
@@ -111,11 +113,10 @@ public class DiaryService {
                 Stream.of(userId) // 랜덤에서는 본인 id도 제외
         ).collect(Collectors.toSet());
 
-        List<DiaryEntity> randomDiary = diaryLowService.findRandomDiary(blockedUserIds);
+        List<RecommendationService.RecommendedDiaryResult> recommendedDiaries =
+                recommendationService.getExploreRecommendations(userId, blockedUserIds);
 
-        Collections.shuffle(randomDiary);
-
-        List<FeedDiaryResponseDto> diaryResponseDtoList = getDiaryResponseDtoList(userId, randomDiary, FeedDiaryResponseDto::from);
+        List<FeedDiaryResponseDto> diaryResponseDtoList = getRecommendationResponseDtoList(userId, recommendedDiaries);
         return new RandomDiaryResponseDto(diaryResponseDtoList);
     }
 
@@ -222,6 +223,44 @@ public class DiaryService {
                 userId,
                 mapper
         );
+    }
+
+    private List<FeedDiaryResponseDto> getRecommendationResponseDtoList(
+            Long userId,
+            List<RecommendationService.RecommendedDiaryResult> recommendedDiaries
+    ) {
+        if (recommendedDiaries.isEmpty()) {
+            return List.of();
+        }
+
+        List<DiaryEntity> diaries = recommendedDiaries.stream()
+                .map(RecommendationService.RecommendedDiaryResult::diary)
+                .toList();
+
+        List<Long> diaryIds = diaries.stream()
+                .map(DiaryEntity::getId)
+                .toList();
+
+        Set<Long> likedDiaryIds = diaryLikeLowService.findLikedDiaryIdsByUser(userId, diaryIds);
+        Map<Long, Long> likeCountsMap = diaryLikeLowService.findLikeCountsByDiaryIds(diaryIds);
+        Set<Long> storedDiaryIds = diaryStoreLowService.findStoredDiaryIdsByUser(userId, diaryIds);
+        Map<Long, RecommendationService.RecommendedDiaryResult> resultMap = recommendedDiaries.stream()
+                .collect(Collectors.toMap(result -> result.diary().getId(), Function.identity()));
+
+        return diaries.stream()
+                .map(diary -> {
+                    RecommendationService.RecommendedDiaryResult result = resultMap.get(diary.getId());
+                    return FeedDiaryResponseDto.from(
+                            diary,
+                            likedDiaryIds.contains(diary.getId()),
+                            storedDiaryIds.contains(diary.getId()),
+                            likeCountsMap.getOrDefault(diary.getId(), 0L),
+                            userId,
+                            result.recommended(),
+                            result.reason()
+                    );
+                })
+                .toList();
     }
 
     private <T extends DiaryResponseDto> T getDiaryResponseDto(Long userId, DiaryEntity diary, DiaryResponseMapper.DiaryResponseDtoMapper<T> mapper) {

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -107,7 +107,6 @@ public class DiaryService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public RandomDiaryResponseDto getRandomDiaries(Long userId) {
 
         Set<Long> blockedUserIds = Stream.concat(
@@ -158,6 +157,19 @@ public class DiaryService {
         DiaryEntity foundDiary = diaryLowService.findDiaryById(diaryId);
 
         foundDiary.validateOwner(foundUser);
+
+        DiaryMusicMetadataRequest musicMetadataRequest = updateRequest.musicMetadata();
+        if (musicMetadataRequest != null && musicMetadataRequest.hasTrackId()) {
+            MusicMetadataEntity musicMetadata = musicMetadataService.findOrCreate(
+                    musicMetadataRequest.sourceType(),
+                    musicMetadataRequest.trackId(),
+                    musicMetadataRequest.artistId(),
+                    musicMetadataRequest.primaryGenreName()
+            );
+            if (musicMetadata != null) {
+                foundDiary.assignMusicMetadata(musicMetadata);
+            }
+        }
 
         diaryLowService.updateDiary(foundDiary, updateRequest.toDomainInfo());
     }

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -7,6 +7,7 @@ import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
 import apptive.team5.recommendation.domain.MusicMetadataEntity;
 import apptive.team5.recommendation.service.MusicMetadataService;
+import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.service.UserBlockLowService;
@@ -42,6 +43,7 @@ public class DiaryService {
     private final DiaryStoreLowService diaryStoreLowService;
     private final UserBlockLowService userBlockLowService;
     private final MusicMetadataService musicMetadataService;
+    private final PreferenceService preferenceService;
 
     @Transactional(readOnly = true)
     public Page<MyDiaryResponseDto> getMyDiaries(Long userId, Pageable pageable) {
@@ -138,6 +140,7 @@ public class DiaryService {
         DiaryEntity savedDiary = diaryLowService.saveDiary(diary);
 
         diaryOrderLowService.addDiaryId(userId, savedDiary.getId());
+        preferenceService.reflectDiaryCreated(foundUser, savedDiary);
 
         return savedDiary;
     }
@@ -163,6 +166,7 @@ public class DiaryService {
         diaryOrderLowService.deleteDiaryId(userId, diaryId);
         diaryLikeLowService.deleteByDiaryId(diaryId);
         diaryMemoLowService.deleteByDiaryId(diaryId);
+        preferenceService.reflectDiaryDeleted(foundUser, foundDiary);
         diaryLowService.deleteDiary(foundDiary);
     }
 

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -5,6 +5,8 @@ import apptive.team5.diary.domain.DiaryOrderEntity;
 import apptive.team5.diary.domain.DiaryScope;
 import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.service.MusicMetadataService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.service.UserBlockLowService;
@@ -39,6 +41,7 @@ public class DiaryService {
     private final DiaryReportLowService diaryReportLowService;
     private final DiaryStoreLowService diaryStoreLowService;
     private final UserBlockLowService userBlockLowService;
+    private final MusicMetadataService musicMetadataService;
 
     @Transactional(readOnly = true)
     public Page<MyDiaryResponseDto> getMyDiaries(Long userId, Pageable pageable) {
@@ -118,6 +121,19 @@ public class DiaryService {
         UserEntity foundUser = userLowService.getReferenceById(userId);
 
         DiaryEntity diary = diaryRequest.toEntity(foundUser);
+        DiaryMusicMetadataRequest musicMetadataRequest = diaryRequest.musicMetadata();
+        MusicMetadataEntity musicMetadata = null;
+        if (musicMetadataRequest != null && musicMetadataRequest.hasTrackId()) {
+            musicMetadata = musicMetadataService.findOrCreate(
+                    musicMetadataRequest.sourceType(),
+                    musicMetadataRequest.trackId(),
+                    musicMetadataRequest.artistId(),
+                    musicMetadataRequest.primaryGenreName()
+            );
+        }
+        if (musicMetadata != null) {
+            diary.assignMusicMetadata(musicMetadata);
+        }
 
         DiaryEntity savedDiary = diaryLowService.saveDiary(diary);
 

--- a/src/main/java/apptive/team5/diary/service/DiaryService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryService.java
@@ -6,6 +6,7 @@ import apptive.team5.diary.domain.DiaryScope;
 import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
 import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.service.ExploreExposureService;
 import apptive.team5.recommendation.service.MusicMetadataService;
 import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.recommendation.service.RecommendationService;
@@ -46,6 +47,7 @@ public class DiaryService {
     private final MusicMetadataService musicMetadataService;
     private final PreferenceService preferenceService;
     private final RecommendationService recommendationService;
+    private final ExploreExposureService exploreExposureService;
 
     @Transactional(readOnly = true)
     public Page<MyDiaryResponseDto> getMyDiaries(Long userId, Pageable pageable) {
@@ -117,6 +119,10 @@ public class DiaryService {
                 recommendationService.getExploreRecommendations(userId, blockedUserIds);
 
         List<FeedDiaryResponseDto> diaryResponseDtoList = getRecommendationResponseDtoList(userId, recommendedDiaries);
+        exploreExposureService.saveExposures(
+                userId,
+                diaryResponseDtoList.stream().map(FeedDiaryResponseDto::diaryId).toList()
+        );
         return new RandomDiaryResponseDto(diaryResponseDtoList);
     }
 

--- a/src/main/java/apptive/team5/diary/service/DiaryStoreLowService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryStoreLowService.java
@@ -40,6 +40,9 @@ public class DiaryStoreLowService {
 
     @Transactional(readOnly = true)
     public Set<Long> findStoredDiaryIdsByUser(Long userId, List<Long> diaryIds) {
+        if (diaryIds == null || diaryIds.isEmpty()) {
+            return Set.of();
+        }
         return diaryStoreRepository.findStoredDiaryIdsByUser(userId, diaryIds);
     }
 

--- a/src/main/java/apptive/team5/diary/service/DiaryStoreService.java
+++ b/src/main/java/apptive/team5/diary/service/DiaryStoreService.java
@@ -6,6 +6,7 @@ import apptive.team5.diary.domain.model.DiaryStoreInfo;
 import apptive.team5.diary.dto.DiaryStoreResponseDto;
 import apptive.team5.diary.dto.FeedDiaryResponseDto;
 import apptive.team5.diary.dto.StoredDiaryResponseDto;
+import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.service.UserLowService;
 import lombok.RequiredArgsConstructor;
@@ -22,19 +23,23 @@ public class DiaryStoreService {
     private final UserLowService userLowService;
     private final DiaryStoreLowService diaryStoreLowService;
     private final DiaryLowService diaryLowService;
+    private final PreferenceService preferenceService;
 
     public DiaryStoreResponseDto toggleDiaryStore(Long userId, Long diaryId) {
         UserEntity user = userLowService.getReferenceById(userId);
 
         if (diaryStoreLowService.existsByUserAndDiaryId(user, diaryId)) {
             DiaryStoreEntity diaryStoreEntity = diaryStoreLowService.findByUserAndDiaryId(user, diaryId);
+            DiaryEntity diary = diaryLowService.findDiaryById(diaryStoreEntity.getDiaryId());
             diaryStoreLowService.deleteById(diaryStoreEntity.getId());
+            preferenceService.reflectDiaryStoreRemoved(user, diary);
             return new DiaryStoreResponseDto(false);
         }
         else {
             DiaryEntity diary = diaryLowService.findDiaryById(diaryId);
             DiaryStoreInfo storeInfo = DiaryStoreInfo.from(diary, user);
             diaryStoreLowService.save(new DiaryStoreEntity(user, storeInfo));
+            preferenceService.reflectDiaryStored(user, diary);
             return new DiaryStoreResponseDto(true);
         }
     }

--- a/src/main/java/apptive/team5/recommendation/domain/MusicMetadataEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/MusicMetadataEntity.java
@@ -1,0 +1,64 @@
+package apptive.team5.recommendation.domain;
+
+import apptive.team5.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "music_metadata",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_music_metadata_source_track",
+                        columnNames = {"source_type", "source_track_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_music_metadata_genre", columnList = "primary_genre_name_raw"),
+                @Index(name = "idx_music_metadata_artist", columnList = "source_artist_id")
+        }
+)
+public class MusicMetadataEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", length = 20)
+    private MusicMetadataSourceType sourceType;
+
+    @Column(name = "source_track_id", length = 64)
+    private String sourceTrackId;
+
+    @Column(name = "source_artist_id", length = 64)
+    private String sourceArtistId;
+
+    @Column(name = "primary_genre_name_raw", length = 128)
+    private String primaryGenreNameRaw;
+
+    public MusicMetadataEntity(
+            MusicMetadataSourceType sourceType,
+            String sourceTrackId,
+            String sourceArtistId,
+            String primaryGenreNameRaw
+    ) {
+        this.sourceType = sourceType;
+        this.sourceTrackId = sourceTrackId;
+        this.sourceArtistId = sourceArtistId;
+        this.primaryGenreNameRaw = primaryGenreNameRaw;
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/domain/MusicMetadataSourceType.java
+++ b/src/main/java/apptive/team5/recommendation/domain/MusicMetadataSourceType.java
@@ -1,0 +1,5 @@
+package apptive.team5.recommendation.domain;
+
+public enum MusicMetadataSourceType {
+    ITUNES
+}

--- a/src/main/java/apptive/team5/recommendation/domain/MusicMetadataSourceType.java
+++ b/src/main/java/apptive/team5/recommendation/domain/MusicMetadataSourceType.java
@@ -1,5 +1,23 @@
 package apptive.team5.recommendation.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+import java.util.Locale;
+
 public enum MusicMetadataSourceType {
-    ITUNES
+    ITUNES;
+
+    @JsonCreator
+    public static MusicMetadataSourceType from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        return Arrays.stream(values())
+                .filter(sourceType -> sourceType.name().equals(normalized))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/apptive/team5/recommendation/domain/UserArtistPreferenceEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/UserArtistPreferenceEntity.java
@@ -1,0 +1,56 @@
+package apptive.team5.recommendation.domain;
+
+import apptive.team5.global.entity.BaseTimeEntity;
+import apptive.team5.user.domain.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "user_artist_preference",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_artist_preference_user_artist",
+                        columnNames = {"user_id", "source_artist_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_artist_preference_user_score", columnList = "user_id, score, updateDateTime")
+        }
+)
+public class UserArtistPreferenceEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(name = "source_artist_id", nullable = false, length = 64)
+    private String sourceArtistId;
+
+    @Column(nullable = false)
+    private int score;
+
+    public UserArtistPreferenceEntity(UserEntity user, String sourceArtistId, int score) {
+        this.user = user;
+        this.sourceArtistId = sourceArtistId;
+        this.score = score;
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/domain/UserArtistPreferenceEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/UserArtistPreferenceEntity.java
@@ -53,4 +53,8 @@ public class UserArtistPreferenceEntity extends BaseTimeEntity {
         this.sourceArtistId = sourceArtistId;
         this.score = score;
     }
+
+    public void adjustScore(int scoreChange) {
+        this.score += scoreChange;
+    }
 }

--- a/src/main/java/apptive/team5/recommendation/domain/UserExploreExposureEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/UserExploreExposureEntity.java
@@ -1,0 +1,45 @@
+package apptive.team5.recommendation.domain;
+
+import apptive.team5.global.entity.BaseTimeEntity;
+import apptive.team5.user.domain.UserEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "user_explore_exposure",
+        indexes = {
+                @Index(name = "idx_user_explore_exposure_user_created", columnList = "user_id, createDateTime"),
+                @Index(name = "idx_user_explore_exposure_user_diary", columnList = "user_id, diary_id")
+        }
+)
+public class UserExploreExposureEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @jakarta.persistence.Column(name = "diary_id", nullable = false)
+    private Long diaryId;
+
+    public UserExploreExposureEntity(UserEntity user, Long diaryId) {
+        this.user = user;
+        this.diaryId = diaryId;
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/domain/UserGenrePreferenceEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/UserGenrePreferenceEntity.java
@@ -1,0 +1,56 @@
+package apptive.team5.recommendation.domain;
+
+import apptive.team5.global.entity.BaseTimeEntity;
+import apptive.team5.user.domain.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "user_genre_preference",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_genre_preference_user_genre",
+                        columnNames = {"user_id", "genre_name_raw"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_genre_preference_user_score", columnList = "user_id, score, updateDateTime")
+        }
+)
+public class UserGenrePreferenceEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(name = "genre_name_raw", nullable = false, length = 128)
+    private String genreNameRaw;
+
+    @Column(nullable = false)
+    private int score;
+
+    public UserGenrePreferenceEntity(UserEntity user, String genreNameRaw, int score) {
+        this.user = user;
+        this.genreNameRaw = genreNameRaw;
+        this.score = score;
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/domain/UserGenrePreferenceEntity.java
+++ b/src/main/java/apptive/team5/recommendation/domain/UserGenrePreferenceEntity.java
@@ -53,4 +53,8 @@ public class UserGenrePreferenceEntity extends BaseTimeEntity {
         this.genreNameRaw = genreNameRaw;
         this.score = score;
     }
+
+    public void adjustScore(int scoreChange) {
+        this.score += scoreChange;
+    }
 }

--- a/src/main/java/apptive/team5/recommendation/repository/MusicMetadataRepository.java
+++ b/src/main/java/apptive/team5/recommendation/repository/MusicMetadataRepository.java
@@ -1,0 +1,15 @@
+package apptive.team5.recommendation.repository;
+
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MusicMetadataRepository extends JpaRepository<MusicMetadataEntity, Long> {
+
+    Optional<MusicMetadataEntity> findBySourceTypeAndSourceTrackId(
+            MusicMetadataSourceType sourceType,
+            String sourceTrackId
+    );
+}

--- a/src/main/java/apptive/team5/recommendation/repository/UserArtistPreferenceRepository.java
+++ b/src/main/java/apptive/team5/recommendation/repository/UserArtistPreferenceRepository.java
@@ -1,0 +1,14 @@
+package apptive.team5.recommendation.repository;
+
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserArtistPreferenceRepository extends JpaRepository<UserArtistPreferenceEntity, Long> {
+
+    Optional<UserArtistPreferenceEntity> findByUser_IdAndSourceArtistId(Long userId, String sourceArtistId);
+
+    List<UserArtistPreferenceEntity> findTop5ByUser_IdOrderByScoreDescUpdateDateTimeDesc(Long userId);
+}

--- a/src/main/java/apptive/team5/recommendation/repository/UserExploreExposureRepository.java
+++ b/src/main/java/apptive/team5/recommendation/repository/UserExploreExposureRepository.java
@@ -1,0 +1,14 @@
+package apptive.team5.recommendation.repository;
+
+import apptive.team5.recommendation.domain.UserExploreExposureEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserExploreExposureRepository extends JpaRepository<UserExploreExposureEntity, Long> {
+
+    List<UserExploreExposureEntity> findTop50ByUser_IdOrderByCreateDateTimeDesc(Long userId);
+
+    void deleteByUser_IdAndCreateDateTimeBefore(Long userId, LocalDateTime cutoff);
+}

--- a/src/main/java/apptive/team5/recommendation/repository/UserExploreExposureRepository.java
+++ b/src/main/java/apptive/team5/recommendation/repository/UserExploreExposureRepository.java
@@ -1,6 +1,7 @@
 package apptive.team5.recommendation.repository;
 
 import apptive.team5.recommendation.domain.UserExploreExposureEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -8,7 +9,7 @@ import java.util.List;
 
 public interface UserExploreExposureRepository extends JpaRepository<UserExploreExposureEntity, Long> {
 
-    List<UserExploreExposureEntity> findTop50ByUser_IdOrderByCreateDateTimeDesc(Long userId);
+    List<UserExploreExposureEntity> findByUser_IdOrderByCreateDateTimeDesc(Long userId, Pageable pageable);
 
     void deleteByUser_IdAndCreateDateTimeBefore(Long userId, LocalDateTime cutoff);
 }

--- a/src/main/java/apptive/team5/recommendation/repository/UserGenrePreferenceRepository.java
+++ b/src/main/java/apptive/team5/recommendation/repository/UserGenrePreferenceRepository.java
@@ -1,0 +1,14 @@
+package apptive.team5.recommendation.repository;
+
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserGenrePreferenceRepository extends JpaRepository<UserGenrePreferenceEntity, Long> {
+
+    Optional<UserGenrePreferenceEntity> findByUser_IdAndGenreNameRaw(Long userId, String genreNameRaw);
+
+    List<UserGenrePreferenceEntity> findTop3ByUser_IdOrderByScoreDescUpdateDateTimeDesc(Long userId);
+}

--- a/src/main/java/apptive/team5/recommendation/service/ExploreExposureService.java
+++ b/src/main/java/apptive/team5/recommendation/service/ExploreExposureService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 @Transactional
 public class ExploreExposureService {
 
+    private static final int RECENT_EXPOSURE_LIMIT = 50;
     private static final int RETENTION_DAYS = 7;
 
     private final UserLowService userLowService;
@@ -24,7 +25,7 @@ public class ExploreExposureService {
 
     @Transactional(readOnly = true)
     public Set<Long> findRecentlyExposedDiaryIds(Long userId) {
-        return userExploreExposureLowService.findTop50ByUserId(userId).stream()
+        return userExploreExposureLowService.findRecentByUserId(userId, RECENT_EXPOSURE_LIMIT).stream()
                 .map(UserExploreExposureEntity::getDiaryId)
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
     }

--- a/src/main/java/apptive/team5/recommendation/service/ExploreExposureService.java
+++ b/src/main/java/apptive/team5/recommendation/service/ExploreExposureService.java
@@ -1,0 +1,46 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.UserExploreExposureEntity;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExploreExposureService {
+
+    private static final int RETENTION_DAYS = 7;
+
+    private final UserLowService userLowService;
+    private final UserExploreExposureLowService userExploreExposureLowService;
+
+    @Transactional(readOnly = true)
+    public Set<Long> findRecentlyExposedDiaryIds(Long userId) {
+        return userExploreExposureLowService.findTop50ByUserId(userId).stream()
+                .map(UserExploreExposureEntity::getDiaryId)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public void saveExposures(Long userId, List<Long> diaryIds) {
+        if (diaryIds == null || diaryIds.isEmpty()) {
+            return;
+        }
+
+        UserEntity user = userLowService.getReferenceById(userId);
+        List<UserExploreExposureEntity> exposures = diaryIds.stream()
+                .distinct()
+                .map(diaryId -> new UserExploreExposureEntity(user, diaryId))
+                .toList();
+
+        userExploreExposureLowService.saveAll(exposures);
+        userExploreExposureLowService.deleteOlderThan(userId, LocalDateTime.now().minusDays(RETENTION_DAYS));
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/MusicMetadataLowService.java
+++ b/src/main/java/apptive/team5/recommendation/service/MusicMetadataLowService.java
@@ -1,0 +1,30 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import apptive.team5.recommendation.repository.MusicMetadataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MusicMetadataLowService {
+
+    private final MusicMetadataRepository musicMetadataRepository;
+
+    public MusicMetadataEntity save(MusicMetadataEntity musicMetadata) {
+        return musicMetadataRepository.save(musicMetadata);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MusicMetadataEntity> findBySourceTypeAndSourceTrackId(
+            MusicMetadataSourceType sourceType,
+            String sourceTrackId
+    ) {
+        return musicMetadataRepository.findBySourceTypeAndSourceTrackId(sourceType, sourceTrackId);
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/MusicMetadataService.java
+++ b/src/main/java/apptive/team5/recommendation/service/MusicMetadataService.java
@@ -2,7 +2,6 @@ package apptive.team5.recommendation.service;
 
 import apptive.team5.recommendation.domain.MusicMetadataEntity;
 import apptive.team5.recommendation.domain.MusicMetadataSourceType;
-import apptive.team5.recommendation.repository.MusicMetadataRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MusicMetadataService {
 
-    private final MusicMetadataRepository musicMetadataRepository;
+    private final MusicMetadataLowService musicMetadataLowService;
 
     public MusicMetadataEntity findOrCreate(
             MusicMetadataSourceType sourceType,
@@ -24,8 +23,8 @@ public class MusicMetadataService {
             return null;
         }
 
-        return musicMetadataRepository.findBySourceTypeAndSourceTrackId(sourceType, sourceTrackId)
-                .orElseGet(() -> musicMetadataRepository.save(
+        return musicMetadataLowService.findBySourceTypeAndSourceTrackId(sourceType, sourceTrackId)
+                .orElseGet(() -> musicMetadataLowService.save(
                         new MusicMetadataEntity(
                                 sourceType,
                                 sourceTrackId,

--- a/src/main/java/apptive/team5/recommendation/service/MusicMetadataService.java
+++ b/src/main/java/apptive/team5/recommendation/service/MusicMetadataService.java
@@ -1,0 +1,37 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import apptive.team5.recommendation.repository.MusicMetadataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MusicMetadataService {
+
+    private final MusicMetadataRepository musicMetadataRepository;
+
+    public MusicMetadataEntity findOrCreate(
+            MusicMetadataSourceType sourceType,
+            String sourceTrackId,
+            String sourceArtistId,
+            String primaryGenreName
+    ) {
+        if (sourceType == null || sourceTrackId == null || sourceTrackId.isBlank()) {
+            return null;
+        }
+
+        return musicMetadataRepository.findBySourceTypeAndSourceTrackId(sourceType, sourceTrackId)
+                .orElseGet(() -> musicMetadataRepository.save(
+                        new MusicMetadataEntity(
+                                sourceType,
+                                sourceTrackId,
+                                sourceArtistId,
+                                primaryGenreName
+                        )
+                ));
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/PreferenceService.java
+++ b/src/main/java/apptive/team5/recommendation/service/PreferenceService.java
@@ -1,0 +1,117 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import apptive.team5.user.domain.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PreferenceService {
+
+    private static final int DIARY_CREATE_SCORE = 5;
+    private static final int DIARY_STORE_SCORE = 4;
+    private static final int DIARY_LIKE_SCORE = 2;
+
+    private final UserGenrePreferenceLowService userGenrePreferenceLowService;
+    private final UserArtistPreferenceLowService userArtistPreferenceLowService;
+
+    public void reflectDiaryCreated(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, DIARY_CREATE_SCORE);
+    }
+
+    public void reflectDiaryDeleted(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, -DIARY_CREATE_SCORE);
+    }
+
+    public void reflectDiaryStored(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, DIARY_STORE_SCORE);
+    }
+
+    public void reflectDiaryStoreRemoved(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, -DIARY_STORE_SCORE);
+    }
+
+    public void reflectDiaryLiked(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, DIARY_LIKE_SCORE);
+    }
+
+    public void reflectDiaryLikeRemoved(UserEntity user, DiaryEntity diary) {
+        applyPreference(user, diary, -DIARY_LIKE_SCORE);
+    }
+
+    private void applyPreference(UserEntity user, DiaryEntity diary, int scoreChange) {
+        if (user == null || diary == null) {
+            return;
+        }
+
+        MusicMetadataEntity musicMetadata = diary.getMusicMetadata();
+        if (musicMetadata == null) {
+            return;
+        }
+
+        applyGenrePreference(user, musicMetadata, scoreChange);
+        applyArtistPreference(user, musicMetadata, scoreChange);
+    }
+
+    private void applyGenrePreference(UserEntity user, MusicMetadataEntity musicMetadata, int scoreChange) {
+        String genreNameRaw = musicMetadata.getPrimaryGenreNameRaw();
+        if (genreNameRaw == null || genreNameRaw.isBlank()) {
+            return;
+        }
+
+        userGenrePreferenceLowService.findByUserIdAndGenreNameRaw(user.getId(), genreNameRaw)
+                .ifPresentOrElse(
+                        preference -> applyGenrePreference(preference, scoreChange),
+                        () -> createGenrePreference(user, genreNameRaw, scoreChange)
+                );
+    }
+
+    private void applyArtistPreference(UserEntity user, MusicMetadataEntity musicMetadata, int scoreChange) {
+        String sourceArtistId = musicMetadata.getSourceArtistId();
+        if (sourceArtistId == null || sourceArtistId.isBlank()) {
+            return;
+        }
+
+        userArtistPreferenceLowService.findByUserIdAndSourceArtistId(user.getId(), sourceArtistId)
+                .ifPresentOrElse(
+                        preference -> applyArtistPreference(preference, scoreChange),
+                        () -> createArtistPreference(user, sourceArtistId, scoreChange)
+                );
+    }
+
+    private void applyGenrePreference(UserGenrePreferenceEntity preference, int scoreChange) {
+        preference.adjustScore(scoreChange);
+        if (preference.getScore() <= 0) {
+            userGenrePreferenceLowService.delete(preference);
+        }
+    }
+
+    private void applyArtistPreference(UserArtistPreferenceEntity preference, int scoreChange) {
+        preference.adjustScore(scoreChange);
+        if (preference.getScore() <= 0) {
+            userArtistPreferenceLowService.delete(preference);
+        }
+    }
+
+    private void createGenrePreference(UserEntity user, String genreNameRaw, int scoreChange) {
+        if (scoreChange <= 0) {
+            return;
+        }
+
+        userGenrePreferenceLowService.save(new UserGenrePreferenceEntity(user, genreNameRaw, scoreChange));
+    }
+
+    private void createArtistPreference(UserEntity user, String sourceArtistId, int scoreChange) {
+        if (scoreChange <= 0) {
+            return;
+        }
+
+        userArtistPreferenceLowService.save(new UserArtistPreferenceEntity(user, sourceArtistId, scoreChange));
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
+++ b/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
@@ -1,0 +1,219 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.domain.DiaryScope;
+import apptive.team5.diary.service.DiaryLikeLowService;
+import apptive.team5.diary.service.DiaryLowService;
+import apptive.team5.diary.service.DiaryStoreLowService;
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationService {
+
+    private static final int DEFAULT_LIMIT = 5;
+    private static final int CANDIDATE_LIMIT = 300;
+    private static final int RECENT_DAYS = 30;
+    private static final List<DiaryScope> EXPLORE_SCOPES = List.of(DiaryScope.PUBLIC, DiaryScope.KILLING_PART);
+
+    private final DiaryLowService diaryLowService;
+    private final DiaryLikeLowService diaryLikeLowService;
+    private final DiaryStoreLowService diaryStoreLowService;
+    private final UserGenrePreferenceLowService userGenrePreferenceLowService;
+    private final UserArtistPreferenceLowService userArtistPreferenceLowService;
+
+    public List<RecommendedDiaryResult> getExploreRecommendations(Long userId, Set<Long> excludedUserIds) {
+        List<DiaryEntity> candidates = diaryLowService.findRecentExploreCandidates(
+                excludedUserIds,
+                EXPLORE_SCOPES,
+                LocalDateTime.now().minusDays(RECENT_DAYS),
+                PageRequest.of(0, CANDIDATE_LIMIT)
+        );
+
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        List<UserGenrePreferenceEntity> topGenres = userGenrePreferenceLowService.findTop3ByUserId(userId);
+        List<UserArtistPreferenceEntity> topArtists = userArtistPreferenceLowService.findTop5ByUserId(userId);
+
+        List<Long> candidateIds = candidates.stream().map(DiaryEntity::getId).toList();
+        Set<Long> likedDiaryIds = diaryLikeLowService.findLikedDiaryIdsByUser(userId, candidateIds);
+        Set<Long> storedDiaryIds = diaryStoreLowService.findStoredDiaryIdsByUser(userId, candidateIds);
+        Map<Long, Long> likeCounts = diaryLikeLowService.findLikeCountsByDiaryIds(candidateIds);
+
+        Map<String, Integer> genreScores = topGenres.stream()
+                .collect(Collectors.toMap(UserGenrePreferenceEntity::getGenreNameRaw, UserGenrePreferenceEntity::getScore));
+        Map<String, Integer> artistScores = topArtists.stream()
+                .collect(Collectors.toMap(UserArtistPreferenceEntity::getSourceArtistId, UserArtistPreferenceEntity::getScore));
+
+        List<RecommendedDiaryResult> selected = new ArrayList<>();
+        Set<Long> selectedDiaryIds = new LinkedHashSet<>();
+
+        if (!genreScores.isEmpty() || !artistScores.isEmpty()) {
+            List<RecommendedDiaryResult> personalized = candidates.stream()
+                    .filter(diary -> diary.getMusicMetadata() != null)
+                    .filter(diary -> !likedDiaryIds.contains(diary.getId()))
+                    .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                    .map(diary -> toPersonalizedResult(diary, likeCounts.getOrDefault(diary.getId(), 0L), genreScores, artistScores))
+                    .filter(Objects::nonNull)
+                    .sorted(RECOMMENDATION_ORDER)
+                    .toList();
+
+            for (RecommendedDiaryResult result : personalized) {
+                if (selected.size() >= DEFAULT_LIMIT) {
+                    break;
+                }
+                if (selectedDiaryIds.add(result.diary().getId())) {
+                    selected.add(result);
+                }
+            }
+        }
+
+        List<RecommendedDiaryResult> fallback = (genreScores.isEmpty() && artistScores.isEmpty())
+                ? buildColdStartResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds)
+                : buildRandomFallbackResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds);
+
+        for (RecommendedDiaryResult result : fallback) {
+            if (selected.size() >= DEFAULT_LIMIT) {
+                break;
+            }
+            if (selectedDiaryIds.add(result.diary().getId())) {
+                selected.add(result);
+            }
+        }
+
+        return selected;
+    }
+
+    private RecommendedDiaryResult toPersonalizedResult(
+            DiaryEntity diary,
+            Long likeCount,
+            Map<String, Integer> genreScores,
+            Map<String, Integer> artistScores
+    ) {
+        String genreName = diary.getMusicMetadata().getPrimaryGenreNameRaw();
+        String artistId = diary.getMusicMetadata().getSourceArtistId();
+
+        Integer genreScore = genreName == null ? null : genreScores.get(genreName);
+        Integer artistScore = artistId == null ? null : artistScores.get(artistId);
+
+        if (genreScore == null && artistScore == null) {
+            return null;
+        }
+
+        double score = scoreGenre(genreScore) + scoreArtist(artistScore) + scorePopularity(likeCount) + scoreFreshness(diary.getCreateDateTime());
+        return new RecommendedDiaryResult(diary, true, determineReason(genreScore, artistScore), score, likeCount);
+    }
+
+    private List<RecommendedDiaryResult> buildColdStartResults(
+            List<DiaryEntity> candidates,
+            Set<Long> likedDiaryIds,
+            Set<Long> storedDiaryIds,
+            Map<Long, Long> likeCounts,
+            Set<Long> selectedDiaryIds
+    ) {
+        return candidates.stream()
+                .filter(diary -> !selectedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !likedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                .map(diary -> new RecommendedDiaryResult(
+                        diary,
+                        true,
+                        "COLD_START_POPULAR",
+                        scorePopularity(likeCounts.getOrDefault(diary.getId(), 0L)) + scoreFreshness(diary.getCreateDateTime()),
+                        likeCounts.getOrDefault(diary.getId(), 0L)
+                ))
+                .sorted(RECOMMENDATION_ORDER)
+                .limit(DEFAULT_LIMIT)
+                .toList();
+    }
+
+    private List<RecommendedDiaryResult> buildRandomFallbackResults(
+            List<DiaryEntity> candidates,
+            Set<Long> likedDiaryIds,
+            Set<Long> storedDiaryIds,
+            Map<Long, Long> likeCounts,
+            Set<Long> selectedDiaryIds
+    ) {
+        List<DiaryEntity> fallbackPool = candidates.stream()
+                .filter(diary -> !selectedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !likedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        Collections.shuffle(fallbackPool);
+
+        return fallbackPool.stream()
+                .limit(DEFAULT_LIMIT)
+                .map(diary -> new RecommendedDiaryResult(
+                        diary,
+                        false,
+                        "FALLBACK_RANDOM",
+                        0.0,
+                        likeCounts.getOrDefault(diary.getId(), 0L)
+                ))
+                .toList();
+    }
+
+    private double scoreGenre(Integer genreScore) {
+        if (genreScore == null) {
+            return 0.0;
+        }
+        return Math.min(10.0, Math.sqrt(genreScore) * 2.0);
+    }
+
+    private double scoreArtist(Integer artistScore) {
+        if (artistScore == null) {
+            return 0.0;
+        }
+        return Math.min(8.0, Math.sqrt(artistScore) * 1.5);
+    }
+
+    private double scorePopularity(Long likeCount) {
+        return Math.min(5.0, Math.log1p(likeCount) * 1.2);
+    }
+
+    private double scoreFreshness(LocalDateTime createdAt) {
+        long days = ChronoUnit.DAYS.between(createdAt, LocalDateTime.now());
+
+        if (days <= 1) return 4.0;
+        if (days <= 3) return 3.0;
+        if (days <= 7) return 2.0;
+        if (days <= 14) return 1.0;
+        if (days <= 30) return 0.5;
+        return 0.0;
+    }
+
+    private String determineReason(Integer genreScore, Integer artistScore) {
+        if (genreScore != null && artistScore != null) return "GENRE_AND_ARTIST_MATCH";
+        if (genreScore != null) return "GENRE_MATCH";
+        return "ARTIST_MATCH";
+    }
+
+    private static final Comparator<RecommendedDiaryResult> RECOMMENDATION_ORDER =
+            Comparator.comparingDouble(RecommendedDiaryResult::score)
+                    .reversed()
+                    .thenComparing(RecommendedDiaryResult::likeCount, Comparator.reverseOrder())
+                    .thenComparing(result -> result.diary().getCreateDateTime(), Comparator.reverseOrder())
+                    .thenComparing(result -> result.diary().getId(), Comparator.reverseOrder());
+
+    public record RecommendedDiaryResult(
+            DiaryEntity diary,
+            boolean recommended,
+            String reason,
+            double score,
+            Long likeCount
+    ) {}
+}

--- a/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
+++ b/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
@@ -35,21 +35,17 @@ public class RecommendationService {
     private final ExploreExposureService exploreExposureService;
 
     public List<RecommendedDiaryResult> getExploreRecommendations(Long userId, Set<Long> excludedUserIds) {
-        List<DiaryEntity> candidates = diaryLowService.findRecentExploreCandidates(
+        List<DiaryEntity> recentCandidates = diaryLowService.findRecentExploreCandidates(
                 excludedUserIds,
                 EXPLORE_SCOPES,
                 LocalDateTime.now().minusDays(RECENT_DAYS),
                 PageRequest.of(0, CANDIDATE_LIMIT)
         );
 
-        if (candidates.isEmpty()) {
-            return List.of();
-        }
-
         List<UserGenrePreferenceEntity> topGenres = userGenrePreferenceLowService.findTop3ByUserId(userId);
         List<UserArtistPreferenceEntity> topArtists = userArtistPreferenceLowService.findTop5ByUserId(userId);
 
-        List<Long> candidateIds = candidates.stream().map(DiaryEntity::getId).toList();
+        List<Long> candidateIds = recentCandidates.stream().map(DiaryEntity::getId).toList();
         Set<Long> likedDiaryIds = diaryLikeLowService.findLikedDiaryIdsByUser(userId, candidateIds);
         Set<Long> storedDiaryIds = diaryStoreLowService.findStoredDiaryIdsByUser(userId, candidateIds);
         Map<Long, Long> likeCounts = diaryLikeLowService.findLikeCountsByDiaryIds(candidateIds);
@@ -64,7 +60,7 @@ public class RecommendationService {
         Set<Long> selectedDiaryIds = new LinkedHashSet<>();
 
         if (!genreScores.isEmpty() || !artistScores.isEmpty()) {
-            List<RecommendedDiaryResult> personalized = candidates.stream()
+            List<RecommendedDiaryResult> personalized = recentCandidates.stream()
                     .filter(diary -> diary.getMusicMetadata() != null)
                     .filter(diary -> !likedDiaryIds.contains(diary.getId()))
                     .filter(diary -> !storedDiaryIds.contains(diary.getId()))
@@ -78,22 +74,61 @@ public class RecommendationService {
         }
 
         List<RecommendedDiaryResult> fallback = (genreScores.isEmpty() && artistScores.isEmpty())
-                ? buildColdStartResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds)
-                : buildRandomFallbackResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds, true);
+                ? buildColdStartResults(recentCandidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds)
+                : buildRandomFallbackResults(recentCandidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds, true, true);
 
         addUntilLimit(selected, selectedDiaryIds, fallback);
 
         if (selected.size() < DEFAULT_LIMIT) {
             List<RecommendedDiaryResult> relaxedFallback = buildRandomFallbackResults(
-                    candidates,
+                    recentCandidates,
                     likedDiaryIds,
                     storedDiaryIds,
                     likeCounts,
                     selectedDiaryIds,
                     recentlyExposedDiaryIds,
-                    false
+                    false,
+                    true
             );
             addUntilLimit(selected, selectedDiaryIds, relaxedFallback);
+        }
+
+        if (selected.size() < DEFAULT_LIMIT) {
+            List<DiaryEntity> allCandidates = diaryLowService.findExploreCandidates(
+                    excludedUserIds,
+                    EXPLORE_SCOPES,
+                    PageRequest.of(0, CANDIDATE_LIMIT)
+            );
+            List<Long> allCandidateIds = allCandidates.stream().map(DiaryEntity::getId).toList();
+            Set<Long> allLikedDiaryIds = diaryLikeLowService.findLikedDiaryIdsByUser(userId, allCandidateIds);
+            Set<Long> allStoredDiaryIds = diaryStoreLowService.findStoredDiaryIdsByUser(userId, allCandidateIds);
+            Map<Long, Long> allLikeCounts = diaryLikeLowService.findLikeCountsByDiaryIds(allCandidateIds);
+
+            List<RecommendedDiaryResult> olderFallback = buildRandomFallbackResults(
+                    allCandidates,
+                    allLikedDiaryIds,
+                    allStoredDiaryIds,
+                    allLikeCounts,
+                    selectedDiaryIds,
+                    recentlyExposedDiaryIds,
+                    false,
+                    true
+            );
+            addUntilLimit(selected, selectedDiaryIds, olderFallback);
+
+            if (selected.size() < DEFAULT_LIMIT) {
+                List<RecommendedDiaryResult> relaxedInteractionFallback = buildRandomFallbackResults(
+                        allCandidates,
+                        allLikedDiaryIds,
+                        allStoredDiaryIds,
+                        allLikeCounts,
+                        selectedDiaryIds,
+                        recentlyExposedDiaryIds,
+                        false,
+                        false
+                );
+                addUntilLimit(selected, selectedDiaryIds, relaxedInteractionFallback);
+            }
         }
 
         return selected;
@@ -151,12 +186,13 @@ public class RecommendationService {
             Map<Long, Long> likeCounts,
             Set<Long> selectedDiaryIds,
             Set<Long> recentlyExposedDiaryIds,
-            boolean excludeRecentExposure
+            boolean excludeRecentExposure,
+            boolean excludeInteractions
     ) {
         List<DiaryEntity> fallbackPool = candidates.stream()
                 .filter(diary -> !selectedDiaryIds.contains(diary.getId()))
-                .filter(diary -> !likedDiaryIds.contains(diary.getId()))
-                .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !excludeInteractions || !likedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !excludeInteractions || !storedDiaryIds.contains(diary.getId()))
                 .filter(diary -> !excludeRecentExposure || !recentlyExposedDiaryIds.contains(diary.getId()))
                 .collect(Collectors.toCollection(ArrayList::new));
 

--- a/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
+++ b/src/main/java/apptive/team5/recommendation/service/RecommendationService.java
@@ -32,6 +32,7 @@ public class RecommendationService {
     private final DiaryStoreLowService diaryStoreLowService;
     private final UserGenrePreferenceLowService userGenrePreferenceLowService;
     private final UserArtistPreferenceLowService userArtistPreferenceLowService;
+    private final ExploreExposureService exploreExposureService;
 
     public List<RecommendedDiaryResult> getExploreRecommendations(Long userId, Set<Long> excludedUserIds) {
         List<DiaryEntity> candidates = diaryLowService.findRecentExploreCandidates(
@@ -52,6 +53,7 @@ public class RecommendationService {
         Set<Long> likedDiaryIds = diaryLikeLowService.findLikedDiaryIdsByUser(userId, candidateIds);
         Set<Long> storedDiaryIds = diaryStoreLowService.findStoredDiaryIdsByUser(userId, candidateIds);
         Map<Long, Long> likeCounts = diaryLikeLowService.findLikeCountsByDiaryIds(candidateIds);
+        Set<Long> recentlyExposedDiaryIds = exploreExposureService.findRecentlyExposedDiaryIds(userId);
 
         Map<String, Integer> genreScores = topGenres.stream()
                 .collect(Collectors.toMap(UserGenrePreferenceEntity::getGenreNameRaw, UserGenrePreferenceEntity::getScore));
@@ -66,32 +68,32 @@ public class RecommendationService {
                     .filter(diary -> diary.getMusicMetadata() != null)
                     .filter(diary -> !likedDiaryIds.contains(diary.getId()))
                     .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                    .filter(diary -> !recentlyExposedDiaryIds.contains(diary.getId()))
                     .map(diary -> toPersonalizedResult(diary, likeCounts.getOrDefault(diary.getId(), 0L), genreScores, artistScores))
                     .filter(Objects::nonNull)
                     .sorted(RECOMMENDATION_ORDER)
                     .toList();
 
-            for (RecommendedDiaryResult result : personalized) {
-                if (selected.size() >= DEFAULT_LIMIT) {
-                    break;
-                }
-                if (selectedDiaryIds.add(result.diary().getId())) {
-                    selected.add(result);
-                }
-            }
+            addUntilLimit(selected, selectedDiaryIds, personalized);
         }
 
         List<RecommendedDiaryResult> fallback = (genreScores.isEmpty() && artistScores.isEmpty())
-                ? buildColdStartResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds)
-                : buildRandomFallbackResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds);
+                ? buildColdStartResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds)
+                : buildRandomFallbackResults(candidates, likedDiaryIds, storedDiaryIds, likeCounts, selectedDiaryIds, recentlyExposedDiaryIds, true);
 
-        for (RecommendedDiaryResult result : fallback) {
-            if (selected.size() >= DEFAULT_LIMIT) {
-                break;
-            }
-            if (selectedDiaryIds.add(result.diary().getId())) {
-                selected.add(result);
-            }
+        addUntilLimit(selected, selectedDiaryIds, fallback);
+
+        if (selected.size() < DEFAULT_LIMIT) {
+            List<RecommendedDiaryResult> relaxedFallback = buildRandomFallbackResults(
+                    candidates,
+                    likedDiaryIds,
+                    storedDiaryIds,
+                    likeCounts,
+                    selectedDiaryIds,
+                    recentlyExposedDiaryIds,
+                    false
+            );
+            addUntilLimit(selected, selectedDiaryIds, relaxedFallback);
         }
 
         return selected;
@@ -122,12 +124,14 @@ public class RecommendationService {
             Set<Long> likedDiaryIds,
             Set<Long> storedDiaryIds,
             Map<Long, Long> likeCounts,
-            Set<Long> selectedDiaryIds
+            Set<Long> selectedDiaryIds,
+            Set<Long> recentlyExposedDiaryIds
     ) {
         return candidates.stream()
                 .filter(diary -> !selectedDiaryIds.contains(diary.getId()))
                 .filter(diary -> !likedDiaryIds.contains(diary.getId()))
                 .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !recentlyExposedDiaryIds.contains(diary.getId()))
                 .map(diary -> new RecommendedDiaryResult(
                         diary,
                         true,
@@ -145,12 +149,15 @@ public class RecommendationService {
             Set<Long> likedDiaryIds,
             Set<Long> storedDiaryIds,
             Map<Long, Long> likeCounts,
-            Set<Long> selectedDiaryIds
+            Set<Long> selectedDiaryIds,
+            Set<Long> recentlyExposedDiaryIds,
+            boolean excludeRecentExposure
     ) {
         List<DiaryEntity> fallbackPool = candidates.stream()
                 .filter(diary -> !selectedDiaryIds.contains(diary.getId()))
                 .filter(diary -> !likedDiaryIds.contains(diary.getId()))
                 .filter(diary -> !storedDiaryIds.contains(diary.getId()))
+                .filter(diary -> !excludeRecentExposure || !recentlyExposedDiaryIds.contains(diary.getId()))
                 .collect(Collectors.toCollection(ArrayList::new));
 
         Collections.shuffle(fallbackPool);
@@ -165,6 +172,21 @@ public class RecommendationService {
                         likeCounts.getOrDefault(diary.getId(), 0L)
                 ))
                 .toList();
+    }
+
+    private void addUntilLimit(
+            List<RecommendedDiaryResult> selected,
+            Set<Long> selectedDiaryIds,
+            List<RecommendedDiaryResult> candidates
+    ) {
+        for (RecommendedDiaryResult result : candidates) {
+            if (selected.size() >= DEFAULT_LIMIT) {
+                break;
+            }
+            if (selectedDiaryIds.add(result.diary().getId())) {
+                selected.add(result);
+            }
+        }
     }
 
     private double scoreGenre(Integer genreScore) {

--- a/src/main/java/apptive/team5/recommendation/service/UserArtistPreferenceLowService.java
+++ b/src/main/java/apptive/team5/recommendation/service/UserArtistPreferenceLowService.java
@@ -1,0 +1,36 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import apptive.team5.recommendation.repository.UserArtistPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserArtistPreferenceLowService {
+
+    private final UserArtistPreferenceRepository userArtistPreferenceRepository;
+
+    public UserArtistPreferenceEntity save(UserArtistPreferenceEntity preference) {
+        return userArtistPreferenceRepository.save(preference);
+    }
+
+    public void delete(UserArtistPreferenceEntity preference) {
+        userArtistPreferenceRepository.delete(preference);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserArtistPreferenceEntity> findByUserIdAndSourceArtistId(Long userId, String sourceArtistId) {
+        return userArtistPreferenceRepository.findByUser_IdAndSourceArtistId(userId, sourceArtistId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserArtistPreferenceEntity> findTop5ByUserId(Long userId) {
+        return userArtistPreferenceRepository.findTop5ByUser_IdOrderByScoreDescUpdateDateTimeDesc(userId);
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/UserExploreExposureLowService.java
+++ b/src/main/java/apptive/team5/recommendation/service/UserExploreExposureLowService.java
@@ -1,0 +1,31 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.UserExploreExposureEntity;
+import apptive.team5.recommendation.repository.UserExploreExposureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserExploreExposureLowService {
+
+    private final UserExploreExposureRepository userExploreExposureRepository;
+
+    public List<UserExploreExposureEntity> saveAll(List<UserExploreExposureEntity> exposures) {
+        return userExploreExposureRepository.saveAll(exposures);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserExploreExposureEntity> findTop50ByUserId(Long userId) {
+        return userExploreExposureRepository.findTop50ByUser_IdOrderByCreateDateTimeDesc(userId);
+    }
+
+    public void deleteOlderThan(Long userId, LocalDateTime cutoff) {
+        userExploreExposureRepository.deleteByUser_IdAndCreateDateTimeBefore(userId, cutoff);
+    }
+}

--- a/src/main/java/apptive/team5/recommendation/service/UserExploreExposureLowService.java
+++ b/src/main/java/apptive/team5/recommendation/service/UserExploreExposureLowService.java
@@ -3,6 +3,7 @@ package apptive.team5.recommendation.service;
 import apptive.team5.recommendation.domain.UserExploreExposureEntity;
 import apptive.team5.recommendation.repository.UserExploreExposureRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +22,8 @@ public class UserExploreExposureLowService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserExploreExposureEntity> findTop50ByUserId(Long userId) {
-        return userExploreExposureRepository.findTop50ByUser_IdOrderByCreateDateTimeDesc(userId);
+    public List<UserExploreExposureEntity> findRecentByUserId(Long userId, int limit) {
+        return userExploreExposureRepository.findByUser_IdOrderByCreateDateTimeDesc(userId, PageRequest.of(0, limit));
     }
 
     public void deleteOlderThan(Long userId, LocalDateTime cutoff) {

--- a/src/main/java/apptive/team5/recommendation/service/UserGenrePreferenceLowService.java
+++ b/src/main/java/apptive/team5/recommendation/service/UserGenrePreferenceLowService.java
@@ -1,0 +1,36 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import apptive.team5.recommendation.repository.UserGenrePreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserGenrePreferenceLowService {
+
+    private final UserGenrePreferenceRepository userGenrePreferenceRepository;
+
+    public UserGenrePreferenceEntity save(UserGenrePreferenceEntity preference) {
+        return userGenrePreferenceRepository.save(preference);
+    }
+
+    public void delete(UserGenrePreferenceEntity preference) {
+        userGenrePreferenceRepository.delete(preference);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserGenrePreferenceEntity> findByUserIdAndGenreNameRaw(Long userId, String genreNameRaw) {
+        return userGenrePreferenceRepository.findByUser_IdAndGenreNameRaw(userId, genreNameRaw);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserGenrePreferenceEntity> findTop3ByUserId(Long userId) {
+        return userGenrePreferenceRepository.findTop3ByUser_IdOrderByScoreDescUpdateDateTimeDesc(userId);
+    }
+}

--- a/src/test/java/apptive/team5/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/apptive/team5/diary/controller/DiaryControllerTest.java
@@ -351,6 +351,47 @@ public class DiaryControllerTest {
     }
 
     @Test
+    @DisplayName("알 수 없는 sourceType 이면 메타 저장 없이 다이어리 생성")
+    void createDiary_withUnknownSourceType() throws Exception {
+        TestSecurityContextHolderInjection.inject(testUser.getId(), testUser.getRoleType());
+
+        String requestBody = """
+                {
+                  "artist": "Test Artist",
+                  "musicTitle": "Test Music",
+                  "albumImageUrl": "image.url",
+                  "videoUrl": "url",
+                  "content": "Test Content",
+                  "scope": "PUBLIC",
+                  "duration": "30S",
+                  "totalDuration": "PT2M58S",
+                  "start": "PT1M1S",
+                  "end": "PT1M31S",
+                  "musicMetadata": {
+                    "sourceType": "SPOTIFY",
+                    "trackId": "track-1",
+                    "artistId": "artist-1",
+                    "primaryGenreName": "K-Pop"
+                  }
+                }
+                """;
+
+        String header = mockMvc.perform(post("/api/diaries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(MockMvcResultMatchers.header().exists("location"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getHeader("location");
+
+        Long id = Long.parseLong(header.substring(header.lastIndexOf("/") + 1));
+        DiaryEntity diaryEntity = diaryRepository.findById(id).orElseThrow();
+
+        assertThat(diaryEntity.getMusicMetadata()).isNull();
+        assertThat(diaryEntity.getMusicTitle()).isEqualTo("Test Music");
+    }
+
+    @Test
     @DisplayName("다이어리 수정 API")
     void updateDiary() throws Exception {
         // given

--- a/src/test/java/apptive/team5/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/apptive/team5/diary/controller/DiaryControllerTest.java
@@ -425,6 +425,8 @@ public class DiaryControllerTest {
         assertSoftly(softly -> {
             softly.assertThat(randomDiaryResponseDto.pageSize()).isEqualTo(1);
             softly.assertThat(randomDiaryResponseDto.content().get(0).diaryId()).isEqualTo(diary.getId());
+            softly.assertThat(randomDiaryResponseDto.content().get(0).isRecommended()).isTrue();
+            softly.assertThat(randomDiaryResponseDto.content().get(0).recommendationReason()).isEqualTo("COLD_START_POPULAR");
         });
     }
 
@@ -463,6 +465,7 @@ public class DiaryControllerTest {
             softly.assertThat(randomDiaryResponseDto.content()).extracting(FeedDiaryResponseDto::userId)
                     .contains(visibleUser.getId())
                     .doesNotContain(testUser.getId(), blockedUser.getId());
+            softly.assertThat(randomDiaryResponseDto.content()).allMatch(FeedDiaryResponseDto::isRecommended);
         });
     }
 }

--- a/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryLikeServiceTest.java
@@ -5,9 +5,12 @@ import apptive.team5.diary.domain.DiaryEntity;
 import apptive.team5.diary.domain.DiaryLikeEntity;
 import apptive.team5.diary.domain.DiaryScope;
 import apptive.team5.diary.dto.DiaryLikeResponseDto;
+import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.global.exception.DuplicateException;
 import apptive.team5.global.exception.NotFoundEntityException;
+import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserBlockLowService;
 import apptive.team5.user.service.UserLowService;
 import apptive.team5.util.TestUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +45,12 @@ class DiaryLikeServiceTest {
 
     @Mock
     private AlarmDispatchService alarmDispatchService;
+    @Mock
+    private SubscribeLowService subscribeLowService;
+    @Mock
+    private UserBlockLowService userBlockLowService;
+    @Mock
+    private PreferenceService preferenceService;
 
     @Test
     @DisplayName("좋아요 토글 - 좋아요 없을 때")
@@ -69,6 +78,7 @@ class DiaryLikeServiceTest {
         verify(diaryLowService).findDiaryById(diaryId);
         verify(diaryLikeLowService).existsByUserAndDiary(user, diary);
         verify(diaryLikeLowService).saveDiaryLike(any(DiaryLikeEntity.class));
+        verify(preferenceService).reflectDiaryLiked(user, diary);
         verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService, alarmDispatchService);
     }
 
@@ -101,6 +111,7 @@ class DiaryLikeServiceTest {
         verify(diaryLikeLowService).existsByUserAndDiary(user, diary);
         verify(diaryLikeLowService).findByUserAndDiary(user, diary);
         verify(diaryLikeLowService).deleteDiaryLike(diaryLike);
+        verify(preferenceService).reflectDiaryLikeRemoved(user, diary);
         verifyNoInteractions(alarmDispatchService);
         verifyNoMoreInteractions(userLowService, diaryLowService, diaryLikeLowService);
     }

--- a/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
@@ -8,6 +8,7 @@ import apptive.team5.diary.domain.model.DiaryStoreInfo;
 import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
 import apptive.team5.recommendation.service.MusicMetadataService;
+import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.SocialType;
 import apptive.team5.user.domain.UserEntity;
@@ -59,6 +60,8 @@ public class DiaryServiceTest {
     private UserBlockLowService userBlockLowService;
     @Mock
     private MusicMetadataService musicMetadataService;
+    @Mock
+    private PreferenceService preferenceService;
 
     @Mock
     private DiaryLowService diaryLowService;
@@ -284,6 +287,7 @@ public class DiaryServiceTest {
         verify(userLowService).getReferenceById(any(Long.class));
         verify(diaryLowService).saveDiary(any(DiaryEntity.class));
         verify(diaryOrderLowService).addDiaryId(user.getId(), savedDiary.getId());
+        verify(preferenceService).reflectDiaryCreated(user, savedDiary);
 
         verifyNoMoreInteractions(userLowService, diaryLowService);
     }
@@ -333,6 +337,7 @@ public class DiaryServiceTest {
         verify(diaryLowService).deleteDiary(any(DiaryEntity.class));
         verify(diaryStoreLowService, never()).deleteByDiaryId(any(Long.class));
         verify(diaryMemoLowService).deleteByDiaryId(any(Long.class));
+        verify(preferenceService).reflectDiaryDeleted(user, diary);
 
         verifyNoMoreInteractions(userLowService, diaryLowService);
     }
@@ -361,6 +366,7 @@ public class DiaryServiceTest {
 
         verify(diaryStoreLowService, never()).deleteByDiaryId(diaryId);
         verify(diaryMemoLowService).deleteByDiaryId(diaryId);
+        verify(preferenceService).reflectDiaryDeleted(user, diary);
     }
 
     @Test
@@ -417,6 +423,7 @@ public class DiaryServiceTest {
 
         // then
         verify(diaryOrderLowService).addDiaryId(userId, 100L);
+        verify(preferenceService).reflectDiaryCreated(user, newDiary);
     }
 
     @Test
@@ -438,5 +445,6 @@ public class DiaryServiceTest {
         verify(diaryReportLowService).deleteByDiaryId(any(Long.class));
         verify(diaryOrderLowService).deleteDiaryId(userId, diaryId);
         verify(diaryMemoLowService).deleteByDiaryId(diaryId);
+        verify(preferenceService).reflectDiaryDeleted(user, diary);
     }
 }

--- a/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
@@ -7,9 +7,12 @@ import apptive.team5.diary.domain.DiaryStoreEntity;
 import apptive.team5.diary.domain.model.DiaryStoreInfo;
 import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
+import apptive.team5.recommendation.service.MusicMetadataService;
+import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.SocialType;
 import apptive.team5.user.domain.UserEntity;
 import apptive.team5.user.domain.UserRoleType;
+import apptive.team5.user.service.UserBlockLowService;
 import apptive.team5.user.service.UserLowService;
 import apptive.team5.util.TestUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +53,12 @@ public class DiaryServiceTest {
 
     @Mock
     private UserLowService userLowService;
+    @Mock
+    private SubscribeLowService subscribeLowService;
+    @Mock
+    private UserBlockLowService userBlockLowService;
+    @Mock
+    private MusicMetadataService musicMetadataService;
 
     @Mock
     private DiaryLowService diaryLowService;

--- a/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
@@ -9,8 +9,10 @@ import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
 import apptive.team5.recommendation.domain.MusicMetadataEntity;
 import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import apptive.team5.recommendation.service.ExploreExposureService;
 import apptive.team5.recommendation.service.MusicMetadataService;
 import apptive.team5.recommendation.service.PreferenceService;
+import apptive.team5.recommendation.service.RecommendationService;
 import apptive.team5.subscribe.service.SubscribeLowService;
 import apptive.team5.user.domain.SocialType;
 import apptive.team5.user.domain.UserEntity;
@@ -64,6 +66,10 @@ public class DiaryServiceTest {
     private MusicMetadataService musicMetadataService;
     @Mock
     private PreferenceService preferenceService;
+    @Mock
+    private RecommendationService recommendationService;
+    @Mock
+    private ExploreExposureService exploreExposureService;
 
     @Mock
     private DiaryLowService diaryLowService;
@@ -521,5 +527,28 @@ public class DiaryServiceTest {
         verify(diaryOrderLowService).deleteDiaryId(userId, diaryId);
         verify(diaryMemoLowService).deleteByDiaryId(diaryId);
         verify(preferenceService).reflectDiaryDeleted(user, diary);
+    }
+
+    @Test
+    @DisplayName("탐색 다이어리 응답 후 노출 이력 저장")
+    void getRandomDiaries_persistsExploreExposures() {
+        Long userId = 1L;
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        DiaryEntity diary = TestUtil.makeDiaryEntityWithScope(user, DiaryScope.PUBLIC);
+        ReflectionTestUtils.setField(diary, "id", 100L);
+
+        given(userBlockLowService.getBlockedUserIds(userId)).willReturn(Set.of());
+        given(recommendationService.getExploreRecommendations(userId, Set.of(userId)))
+                .willReturn(List.of(new RecommendationService.RecommendedDiaryResult(diary, true, "COLD_START_POPULAR", 3.0, 2L)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(100L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(100L))).willReturn(java.util.Map.of(100L, 2L));
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(100L))).willReturn(Set.of());
+
+        RandomDiaryResponseDto result = diaryService.getRandomDiaries(userId);
+
+        assertThat(result.content()).hasSize(1);
+        verify(exploreExposureService).saveExposures(userId, List.of(100L));
     }
 }

--- a/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
@@ -398,6 +398,50 @@ public class DiaryServiceTest {
     }
 
     @Test
+    @DisplayName("다이어리 수정 시 음악 메타가 있으면 저장 후 연결한다")
+    void updateDiary_withMusicMetadata_assignsMetadata() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        Long diaryId = 1L;
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        DiaryUpdateRequestDto updateRequest = new DiaryUpdateRequestDto(
+                "Updated Artist",
+                "Updated Music",
+                "updated.image.url",
+                "updated.url",
+                "Updated Content",
+                DiaryScope.PUBLIC,
+                "45S",
+                "PT3M10S",
+                "PT1M10S",
+                "PT1M55S",
+                new DiaryMusicMetadataRequest(
+                        MusicMetadataSourceType.ITUNES,
+                        "track-2",
+                        "artist-2",
+                        "Pop"
+                )
+        );
+
+        MusicMetadataEntity musicMetadata = new MusicMetadataEntity(
+                MusicMetadataSourceType.ITUNES,
+                "track-2",
+                "artist-2",
+                "Pop"
+        );
+
+        given(userLowService.getReferenceById(user.getId())).willReturn(user);
+        given(diaryLowService.findDiaryById(diaryId)).willReturn(diary);
+        given(musicMetadataService.findOrCreate(MusicMetadataSourceType.ITUNES, "track-2", "artist-2", "Pop"))
+                .willReturn(musicMetadata);
+
+        diaryService.updateDiary(user.getId(), diaryId, updateRequest);
+
+        assertThat(diary.getMusicMetadata()).isEqualTo(musicMetadata);
+        verify(musicMetadataService).findOrCreate(MusicMetadataSourceType.ITUNES, "track-2", "artist-2", "Pop");
+        verify(diaryLowService).updateDiary(any(DiaryEntity.class), any());
+    }
+
+    @Test
     @DisplayName("다이어리 삭제")
     void deleteDiary() {
         // given

--- a/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryServiceTest.java
@@ -7,6 +7,8 @@ import apptive.team5.diary.domain.DiaryStoreEntity;
 import apptive.team5.diary.domain.model.DiaryStoreInfo;
 import apptive.team5.diary.dto.*;
 import apptive.team5.diary.mapper.DiaryResponseMapper;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
 import apptive.team5.recommendation.service.MusicMetadataService;
 import apptive.team5.recommendation.service.PreferenceService;
 import apptive.team5.subscribe.service.SubscribeLowService;
@@ -290,6 +292,79 @@ public class DiaryServiceTest {
         verify(preferenceService).reflectDiaryCreated(user, savedDiary);
 
         verifyNoMoreInteractions(userLowService, diaryLowService);
+    }
+
+    @Test
+    @DisplayName("다이어리 생성 시 음악 메타가 있으면 저장 후 연결한다")
+    void createDiary_withMusicMetadata_assignsMetadata() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryCreateRequest diaryRequest = new DiaryCreateRequest(
+                "Test Artist",
+                "Test Music",
+                "image.url",
+                "url",
+                "Test Content",
+                DiaryScope.PUBLIC,
+                "30S",
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S",
+                new DiaryMusicMetadataRequest(
+                        MusicMetadataSourceType.ITUNES,
+                        "track-1",
+                        "artist-1",
+                        "K-Pop"
+                )
+        );
+
+        MusicMetadataEntity musicMetadata = new MusicMetadataEntity(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                "artist-1",
+                "K-Pop"
+        );
+
+        given(userLowService.getReferenceById(user.getId())).willReturn(user);
+        given(musicMetadataService.findOrCreate(MusicMetadataSourceType.ITUNES, "track-1", "artist-1", "K-Pop"))
+                .willReturn(musicMetadata);
+        given(diaryLowService.saveDiary(any(DiaryEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        DiaryEntity result = diaryService.createDiary(user.getId(), diaryRequest);
+
+        assertThat(result.getMusicMetadata()).isEqualTo(musicMetadata);
+        verify(musicMetadataService).findOrCreate(MusicMetadataSourceType.ITUNES, "track-1", "artist-1", "K-Pop");
+    }
+
+    @Test
+    @DisplayName("다이어리 생성 시 트랙 아이디가 없으면 메타를 조회하지 않는다")
+    void createDiary_withoutTrackId_doesNotLookupMetadata() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryCreateRequest diaryRequest = new DiaryCreateRequest(
+                "Test Artist",
+                "Test Music",
+                "image.url",
+                "url",
+                "Test Content",
+                DiaryScope.PUBLIC,
+                "30S",
+                "PT2M58S",
+                "PT1M1S",
+                "PT1M31S",
+                new DiaryMusicMetadataRequest(
+                        MusicMetadataSourceType.ITUNES,
+                        " ",
+                        "artist-1",
+                        "K-Pop"
+                )
+        );
+
+        given(userLowService.getReferenceById(user.getId())).willReturn(user);
+        given(diaryLowService.saveDiary(any(DiaryEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        DiaryEntity result = diaryService.createDiary(user.getId(), diaryRequest);
+
+        assertThat(result.getMusicMetadata()).isNull();
+        verify(musicMetadataService, never()).findOrCreate(any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/apptive/team5/diary/service/DiaryStoreServiceTest.java
+++ b/src/test/java/apptive/team5/diary/service/DiaryStoreServiceTest.java
@@ -1,0 +1,82 @@
+package apptive.team5.diary.service;
+
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.domain.DiaryStoreEntity;
+import apptive.team5.diary.dto.DiaryStoreResponseDto;
+import apptive.team5.recommendation.service.PreferenceService;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.user.service.UserLowService;
+import apptive.team5.util.TestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryStoreServiceTest {
+
+    @InjectMocks
+    private DiaryStoreService diaryStoreService;
+
+    @Mock
+    private UserLowService userLowService;
+    @Mock
+    private DiaryStoreLowService diaryStoreLowService;
+    @Mock
+    private DiaryLowService diaryLowService;
+    @Mock
+    private PreferenceService preferenceService;
+
+    @Test
+    @DisplayName("보관 추가 시 선호도가 반영된다")
+    void toggleDiaryStore_add_reflectsPreference() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        Long userId = user.getId();
+        Long diaryId = 1L;
+
+        given(userLowService.getReferenceById(userId)).willReturn(user);
+        given(diaryStoreLowService.existsByUserAndDiaryId(user, diaryId)).willReturn(false);
+        given(diaryLowService.findDiaryById(diaryId)).willReturn(diary);
+
+        DiaryStoreResponseDto result = diaryStoreService.toggleDiaryStore(userId, diaryId);
+
+        assertThat(result.isStored()).isTrue();
+        verify(diaryStoreLowService).save(any(DiaryStoreEntity.class));
+        verify(preferenceService).reflectDiaryStored(user, diary);
+        verifyNoMoreInteractions(preferenceService);
+    }
+
+    @Test
+    @DisplayName("보관 취소 시 선호도가 차감된다")
+    void toggleDiaryStore_remove_reflectsPreference() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        Long userId = user.getId();
+        Long diaryId = 1L;
+        ReflectionTestUtils.setField(diary, "id", diaryId);
+
+        DiaryStoreEntity diaryStoreEntity = new DiaryStoreEntity(user, apptive.team5.diary.domain.model.DiaryStoreInfo.from(diary, user));
+
+        given(userLowService.getReferenceById(userId)).willReturn(user);
+        given(diaryStoreLowService.existsByUserAndDiaryId(user, diaryId)).willReturn(true);
+        given(diaryStoreLowService.findByUserAndDiaryId(user, diaryId)).willReturn(diaryStoreEntity);
+        given(diaryLowService.findDiaryById(diaryId)).willReturn(diary);
+
+        DiaryStoreResponseDto result = diaryStoreService.toggleDiaryStore(userId, diaryId);
+
+        assertThat(result.isStored()).isFalse();
+        verify(diaryStoreLowService).deleteById(diaryStoreEntity.getId());
+        verify(preferenceService).reflectDiaryStoreRemoved(user, diary);
+        verifyNoMoreInteractions(preferenceService);
+    }
+}

--- a/src/test/java/apptive/team5/recommendation/service/MusicMetadataServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/MusicMetadataServiceTest.java
@@ -1,0 +1,87 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MusicMetadataServiceTest {
+
+    @InjectMocks
+    private MusicMetadataService musicMetadataService;
+
+    @Mock
+    private MusicMetadataLowService musicMetadataLowService;
+
+    @Test
+    @DisplayName("이미 존재하는 메타데이터가 있으면 재사용한다")
+    void findOrCreate_returnsExistingMetadata() {
+        MusicMetadataEntity existing = new MusicMetadataEntity(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                "artist-1",
+                "K-Pop"
+        );
+
+        given(musicMetadataLowService.findBySourceTypeAndSourceTrackId(MusicMetadataSourceType.ITUNES, "track-1"))
+                .willReturn(Optional.of(existing));
+
+        MusicMetadataEntity result = musicMetadataService.findOrCreate(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                "artist-1",
+                "K-Pop"
+        );
+
+        assertThat(result).isEqualTo(existing);
+        verify(musicMetadataLowService, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("메타데이터가 없으면 새로 생성해서 저장한다")
+    void findOrCreate_savesNewMetadata() {
+        given(musicMetadataLowService.findBySourceTypeAndSourceTrackId(MusicMetadataSourceType.ITUNES, "track-1"))
+                .willReturn(Optional.empty());
+
+        musicMetadataService.findOrCreate(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                "artist-1",
+                "K-Pop"
+        );
+
+        ArgumentCaptor<MusicMetadataEntity> captor = ArgumentCaptor.forClass(MusicMetadataEntity.class);
+        verify(musicMetadataLowService).save(captor.capture());
+        assertThat(captor.getValue().getSourceTrackId()).isEqualTo("track-1");
+        assertThat(captor.getValue().getSourceArtistId()).isEqualTo("artist-1");
+        assertThat(captor.getValue().getPrimaryGenreNameRaw()).isEqualTo("K-Pop");
+    }
+
+    @Test
+    @DisplayName("소스 타입이나 트랙 아이디가 없으면 메타데이터를 만들지 않는다")
+    void findOrCreate_withoutRequiredKey_returnsNull() {
+        MusicMetadataEntity result = musicMetadataService.findOrCreate(
+                MusicMetadataSourceType.ITUNES,
+                " ",
+                "artist-1",
+                "K-Pop"
+        );
+
+        assertThat(result).isNull();
+        verify(musicMetadataLowService, never()).findBySourceTypeAndSourceTrackId(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(musicMetadataLowService, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/apptive/team5/recommendation/service/MusicMetadataServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/MusicMetadataServiceTest.java
@@ -27,7 +27,7 @@ class MusicMetadataServiceTest {
     private MusicMetadataLowService musicMetadataLowService;
 
     @Test
-    @DisplayName("이미 존재하는 메타데이터가 있으면 재사용한다")
+    @DisplayName("기존 메타데이터 재사용")
     void findOrCreate_returnsExistingMetadata() {
         MusicMetadataEntity existing = new MusicMetadataEntity(
                 MusicMetadataSourceType.ITUNES,
@@ -51,7 +51,7 @@ class MusicMetadataServiceTest {
     }
 
     @Test
-    @DisplayName("메타데이터가 없으면 새로 생성해서 저장한다")
+    @DisplayName("메타데이터 신규 저장")
     void findOrCreate_savesNewMetadata() {
         given(musicMetadataLowService.findBySourceTypeAndSourceTrackId(MusicMetadataSourceType.ITUNES, "track-1"))
                 .willReturn(Optional.empty());
@@ -71,7 +71,7 @@ class MusicMetadataServiceTest {
     }
 
     @Test
-    @DisplayName("소스 타입이나 트랙 아이디가 없으면 메타데이터를 만들지 않는다")
+    @DisplayName("메타데이터 키 없으면 저장 안 함")
     void findOrCreate_withoutRequiredKey_returnsNull() {
         MusicMetadataEntity result = musicMetadataService.findOrCreate(
                 MusicMetadataSourceType.ITUNES,

--- a/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
@@ -1,0 +1,104 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.util.TestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PreferenceServiceTest {
+
+    @InjectMocks
+    private PreferenceService preferenceService;
+
+    @Mock
+    private UserGenrePreferenceLowService userGenrePreferenceLowService;
+    @Mock
+    private UserArtistPreferenceLowService userArtistPreferenceLowService;
+
+    @Test
+    @DisplayName("작성 반영 시 장르와 아티스트 선호도가 생성된다")
+    void reflectDiaryCreated_createsGenreAndArtistPreferences() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = createDiaryWithMetadata(user);
+
+        given(userGenrePreferenceLowService.findByUserIdAndGenreNameRaw(user.getId(), "K-Pop"))
+                .willReturn(Optional.empty());
+        given(userArtistPreferenceLowService.findByUserIdAndSourceArtistId(user.getId(), "artist-1"))
+                .willReturn(Optional.empty());
+
+        preferenceService.reflectDiaryCreated(user, diary);
+
+        ArgumentCaptor<UserGenrePreferenceEntity> genreCaptor = ArgumentCaptor.forClass(UserGenrePreferenceEntity.class);
+        ArgumentCaptor<UserArtistPreferenceEntity> artistCaptor = ArgumentCaptor.forClass(UserArtistPreferenceEntity.class);
+
+        verify(userGenrePreferenceLowService).save(genreCaptor.capture());
+        verify(userArtistPreferenceLowService).save(artistCaptor.capture());
+
+        assertThat(genreCaptor.getValue().getGenreNameRaw()).isEqualTo("K-Pop");
+        assertThat(genreCaptor.getValue().getScore()).isEqualTo(5);
+        assertThat(artistCaptor.getValue().getSourceArtistId()).isEqualTo("artist-1");
+        assertThat(artistCaptor.getValue().getScore()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("삭제 반영 시 점수가 0 이하가 되면 선호도가 삭제된다")
+    void reflectDiaryDeleted_deletesPreferencesWhenScoreBecomesZero() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = createDiaryWithMetadata(user);
+        UserGenrePreferenceEntity genrePreference = new UserGenrePreferenceEntity(user, "K-Pop", 5);
+        UserArtistPreferenceEntity artistPreference = new UserArtistPreferenceEntity(user, "artist-1", 5);
+
+        given(userGenrePreferenceLowService.findByUserIdAndGenreNameRaw(user.getId(), "K-Pop"))
+                .willReturn(Optional.of(genrePreference));
+        given(userArtistPreferenceLowService.findByUserIdAndSourceArtistId(user.getId(), "artist-1"))
+                .willReturn(Optional.of(artistPreference));
+
+        preferenceService.reflectDiaryDeleted(user, diary);
+
+        verify(userGenrePreferenceLowService).delete(genrePreference);
+        verify(userArtistPreferenceLowService).delete(artistPreference);
+    }
+
+    @Test
+    @DisplayName("메타데이터가 없으면 선호도는 반영되지 않는다")
+    void reflectDiaryLiked_withoutMetadata_doesNothing() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+
+        preferenceService.reflectDiaryLiked(user, diary);
+
+        verify(userGenrePreferenceLowService, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(userArtistPreferenceLowService, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(userGenrePreferenceLowService, never()).delete(org.mockito.ArgumentMatchers.any());
+        verify(userArtistPreferenceLowService, never()).delete(org.mockito.ArgumentMatchers.any());
+    }
+
+    private DiaryEntity createDiaryWithMetadata(UserEntity user) {
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        diary.assignMusicMetadata(new MusicMetadataEntity(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                "artist-1",
+                "K-Pop"
+        ));
+        return diary;
+    }
+}

--- a/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
@@ -78,6 +78,48 @@ class PreferenceServiceTest {
     }
 
     @Test
+    @DisplayName("기존 선호도가 있으면 점수를 누적하고 삭제하지 않는다")
+    void reflectDiaryStored_updatesExistingPreferences() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = createDiaryWithMetadata(user);
+        UserGenrePreferenceEntity genrePreference = new UserGenrePreferenceEntity(user, "K-Pop", 3);
+        UserArtistPreferenceEntity artistPreference = new UserArtistPreferenceEntity(user, "artist-1", 3);
+
+        given(userGenrePreferenceLowService.findByUserIdAndGenreNameRaw(user.getId(), "K-Pop"))
+                .willReturn(Optional.of(genrePreference));
+        given(userArtistPreferenceLowService.findByUserIdAndSourceArtistId(user.getId(), "artist-1"))
+                .willReturn(Optional.of(artistPreference));
+
+        preferenceService.reflectDiaryStored(user, diary);
+
+        assertThat(genrePreference.getScore()).isEqualTo(7);
+        assertThat(artistPreference.getScore()).isEqualTo(7);
+        verify(userGenrePreferenceLowService, never()).delete(genrePreference);
+        verify(userArtistPreferenceLowService, never()).delete(artistPreference);
+    }
+
+    @Test
+    @DisplayName("장르만 있으면 장르 선호도만 반영한다")
+    void reflectDiaryCreated_withGenreOnly_updatesGenreOnly() {
+        UserEntity user = TestUtil.makeUserEntityWithId();
+        DiaryEntity diary = TestUtil.makeDiaryEntity(user);
+        diary.assignMusicMetadata(new MusicMetadataEntity(
+                MusicMetadataSourceType.ITUNES,
+                "track-1",
+                null,
+                "K-Pop"
+        ));
+
+        given(userGenrePreferenceLowService.findByUserIdAndGenreNameRaw(user.getId(), "K-Pop"))
+                .willReturn(Optional.empty());
+
+        preferenceService.reflectDiaryCreated(user, diary);
+
+        verify(userGenrePreferenceLowService).save(org.mockito.ArgumentMatchers.any(UserGenrePreferenceEntity.class));
+        verify(userArtistPreferenceLowService, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
     @DisplayName("메타데이터가 없으면 선호도는 반영되지 않는다")
     void reflectDiaryLiked_withoutMetadata_doesNothing() {
         UserEntity user = TestUtil.makeUserEntityWithId();

--- a/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/PreferenceServiceTest.java
@@ -34,7 +34,7 @@ class PreferenceServiceTest {
     private UserArtistPreferenceLowService userArtistPreferenceLowService;
 
     @Test
-    @DisplayName("작성 반영 시 장르와 아티스트 선호도가 생성된다")
+    @DisplayName("작성 반영 시 장르와 아티스트 선호도 생성")
     void reflectDiaryCreated_createsGenreAndArtistPreferences() {
         UserEntity user = TestUtil.makeUserEntityWithId();
         DiaryEntity diary = createDiaryWithMetadata(user);
@@ -59,7 +59,7 @@ class PreferenceServiceTest {
     }
 
     @Test
-    @DisplayName("삭제 반영 시 점수가 0 이하가 되면 선호도가 삭제된다")
+    @DisplayName("삭제 반영 시 점수 0 이하면 선호도 삭제")
     void reflectDiaryDeleted_deletesPreferencesWhenScoreBecomesZero() {
         UserEntity user = TestUtil.makeUserEntityWithId();
         DiaryEntity diary = createDiaryWithMetadata(user);
@@ -78,7 +78,7 @@ class PreferenceServiceTest {
     }
 
     @Test
-    @DisplayName("기존 선호도가 있으면 점수를 누적하고 삭제하지 않는다")
+    @DisplayName("기존 선호도 점수 누적")
     void reflectDiaryStored_updatesExistingPreferences() {
         UserEntity user = TestUtil.makeUserEntityWithId();
         DiaryEntity diary = createDiaryWithMetadata(user);
@@ -99,7 +99,7 @@ class PreferenceServiceTest {
     }
 
     @Test
-    @DisplayName("장르만 있으면 장르 선호도만 반영한다")
+    @DisplayName("장르만 있으면 장르 선호도만 반영")
     void reflectDiaryCreated_withGenreOnly_updatesGenreOnly() {
         UserEntity user = TestUtil.makeUserEntityWithId();
         DiaryEntity diary = TestUtil.makeDiaryEntity(user);
@@ -120,7 +120,7 @@ class PreferenceServiceTest {
     }
 
     @Test
-    @DisplayName("메타데이터가 없으면 선호도는 반영되지 않는다")
+    @DisplayName("메타데이터 없으면 선호도 미반영")
     void reflectDiaryLiked_withoutMetadata_doesNothing() {
         UserEntity user = TestUtil.makeUserEntityWithId();
         DiaryEntity diary = TestUtil.makeDiaryEntity(user);

--- a/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
@@ -48,7 +48,7 @@ class RecommendationServiceTest {
     private ExploreExposureService exploreExposureService;
 
     @Test
-    @DisplayName("returns personalized results first")
+    @DisplayName("선호도 일치 다이어리 우선 조회")
     void getExploreRecommendations_returnsPersonalizedResultsFirst() {
         Long userId = 1L;
         DiaryEntity matched = createDiary(101L, "K-Pop", "artist-1", 1);
@@ -80,7 +80,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("returns cold start results")
+    @DisplayName("선호도 없으면 인기순 탐색 결과 반환")
     void getExploreRecommendations_returnsColdStartResults() {
         Long userId = 1L;
         DiaryEntity popular = createDiary(201L, null, null, 1);
@@ -106,7 +106,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("returns fallback random when there is no match")
+    @DisplayName("매칭 다이어리 없으면 랜덤 탐색 결과 반환")
     void getExploreRecommendations_returnsFallbackRandomWhenNoMatch() {
         Long userId = 1L;
         DiaryEntity first = createDiary(301L, "Rock", "artist-2", 1);
@@ -133,7 +133,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("excludes recent exposures first")
+    @DisplayName("최근 탐색 노출 다이어리 우선 제외")
     void getExploreRecommendations_excludesRecentlyExposedDiariesFirst() {
         Long userId = 1L;
         DiaryEntity recentExposed = createDiary(401L, "K-Pop", "artist-1", 1);
@@ -160,7 +160,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("relaxes recent exposure filtering when candidates are short")
+    @DisplayName("후보 부족하면 최근 탐색 노출 제외 완화")
     void getExploreRecommendations_relaxesRecentExposureForFallback() {
         Long userId = 1L;
         DiaryEntity first = createDiary(501L, "Rock", "artist-2", 1);
@@ -187,7 +187,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("expands to older public diaries when recent candidates are short")
+    @DisplayName("후보 부족하면 오래된 공개 다이어리까지 확장")
     void getExploreRecommendations_expandsToOlderCandidatesWhenRecentPoolIsShort() {
         Long userId = 1L;
         DiaryEntity recent = createDiary(601L, "Rock", "artist-2", 1);
@@ -218,7 +218,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("relaxes like and store exclusion last")
+    @DisplayName("마지막에 좋아요와 보관 제외 완화")
     void getExploreRecommendations_relaxesInteractionExclusionLast() {
         Long userId = 1L;
         DiaryEntity likedOlder = createDiary(701L, "Rock", "artist-2", 40);

--- a/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
@@ -186,6 +186,66 @@ class RecommendationServiceTest {
         assertThat(result).extracting(r -> r.diary().getId()).containsExactlyInAnyOrder(501L, 502L);
     }
 
+    @Test
+    @DisplayName("expands to older public diaries when recent candidates are short")
+    void getExploreRecommendations_expandsToOlderCandidatesWhenRecentPoolIsShort() {
+        Long userId = 1L;
+        DiaryEntity recent = createDiary(601L, "Rock", "artist-2", 1);
+        DiaryEntity older = createDiary(602L, "Jazz", "artist-3", 40);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(recent));
+        given(diaryLowService.findExploreCandidates(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(recent, older));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(601L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(601L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(601L))).willReturn(java.util.Map.of(601L, 1L));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(601L, 602L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(601L, 602L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(601L, 602L)))
+                .willReturn(java.util.Map.of(601L, 1L, 602L, 2L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of());
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).extracting(r -> r.diary().getId()).contains(602L);
+        assertThat(result).allMatch(recommendedDiaryResult -> "FALLBACK_RANDOM".equals(recommendedDiaryResult.reason()));
+    }
+
+    @Test
+    @DisplayName("relaxes like and store exclusion last")
+    void getExploreRecommendations_relaxesInteractionExclusionLast() {
+        Long userId = 1L;
+        DiaryEntity likedOlder = createDiary(701L, "Rock", "artist-2", 40);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of());
+        given(diaryLowService.findExploreCandidates(any(), any(), any(Pageable.class)))
+                .willReturn(List.of(likedOlder));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of())).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of())).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of())).willReturn(java.util.Map.of());
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(701L))).willReturn(Set.of(701L));
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(701L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(701L))).willReturn(java.util.Map.of(701L, 3L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of());
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).extracting(r -> r.diary().getId()).contains(701L);
+        assertThat(result).allMatch(recommendedDiaryResult -> "FALLBACK_RANDOM".equals(recommendedDiaryResult.reason()));
+    }
+
     private DiaryEntity createDiary(Long diaryId, String genre, String artistId, int daysAgo) {
         UserEntity owner = TestUtil.makeUserEntityWithId();
         ReflectionTestUtils.setField(owner, "id", diaryId + 1000);

--- a/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
@@ -1,0 +1,150 @@
+package apptive.team5.recommendation.service;
+
+import apptive.team5.diary.domain.DiaryEntity;
+import apptive.team5.diary.domain.DiaryScope;
+import apptive.team5.diary.service.DiaryLikeLowService;
+import apptive.team5.diary.service.DiaryLowService;
+import apptive.team5.diary.service.DiaryStoreLowService;
+import apptive.team5.recommendation.domain.MusicMetadataEntity;
+import apptive.team5.recommendation.domain.MusicMetadataSourceType;
+import apptive.team5.recommendation.domain.UserArtistPreferenceEntity;
+import apptive.team5.recommendation.domain.UserGenrePreferenceEntity;
+import apptive.team5.user.domain.UserEntity;
+import apptive.team5.util.TestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceTest {
+
+    @InjectMocks
+    private RecommendationService recommendationService;
+
+    @Mock
+    private DiaryLowService diaryLowService;
+    @Mock
+    private DiaryLikeLowService diaryLikeLowService;
+    @Mock
+    private DiaryStoreLowService diaryStoreLowService;
+    @Mock
+    private UserGenrePreferenceLowService userGenrePreferenceLowService;
+    @Mock
+    private UserArtistPreferenceLowService userArtistPreferenceLowService;
+
+    @Test
+    @DisplayName("선호도 일치 다이어리 우선 조회")
+    void getExploreRecommendations_returnsPersonalizedResultsFirst() {
+        Long userId = 1L;
+        DiaryEntity matched = createDiary(101L, "K-Pop", "artist-1", 1);
+        DiaryEntity unmatched = createDiary(102L, "Rock", "artist-2", 2);
+        DiaryEntity likedMatched = createDiary(103L, "K-Pop", "artist-1", 1);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(matched, unmatched, likedMatched));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(101L, 102L, 103L)))
+                .willReturn(Set.of(103L));
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(101L, 102L, 103L)))
+                .willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(101L, 102L, 103L)))
+                .willReturn(java.util.Map.of(101L, 5L, 102L, 1L, 103L, 10L));
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.getFirst().diary().getId()).isEqualTo(101L);
+        assertThat(result.getFirst().recommended()).isTrue();
+        assertThat(result.getFirst().reason()).isEqualTo("GENRE_AND_ARTIST_MATCH");
+        assertThat(result).extracting(r -> r.diary().getId()).doesNotContain(103L);
+    }
+
+    @Test
+    @DisplayName("선호도 없으면 인기순 탐색 결과 반환")
+    void getExploreRecommendations_returnsColdStartResults() {
+        Long userId = 1L;
+        DiaryEntity popular = createDiary(201L, null, null, 1);
+        DiaryEntity lessPopular = createDiary(202L, null, null, 2);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(popular, lessPopular));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId)).willReturn(List.of());
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId)).willReturn(List.of());
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(201L, 202L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(201L, 202L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(201L, 202L)))
+                .willReturn(java.util.Map.of(201L, 10L, 202L, 1L));
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.getFirst().diary().getId()).isEqualTo(201L);
+        assertThat(result.getFirst().recommended()).isTrue();
+        assertThat(result.getFirst().reason()).isEqualTo("COLD_START_POPULAR");
+    }
+
+    @Test
+    @DisplayName("매칭 다이어리 없으면 랜덤 탐색 결과 반환")
+    void getExploreRecommendations_returnsFallbackRandomWhenNoMatch() {
+        Long userId = 1L;
+        DiaryEntity first = createDiary(301L, "Rock", "artist-2", 1);
+        DiaryEntity second = createDiary(302L, "Jazz", "artist-3", 2);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(first, second));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(301L, 302L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(301L, 302L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(301L, 302L)))
+                .willReturn(java.util.Map.of(301L, 2L, 302L, 3L));
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).isNotEmpty();
+        assertThat(result).allMatch(recommendedDiaryResult -> !recommendedDiaryResult.recommended());
+        assertThat(result).allMatch(recommendedDiaryResult -> "FALLBACK_RANDOM".equals(recommendedDiaryResult.reason()));
+    }
+
+    private DiaryEntity createDiary(Long diaryId, String genre, String artistId, int daysAgo) {
+        UserEntity owner = TestUtil.makeUserEntityWithId();
+        ReflectionTestUtils.setField(owner, "id", diaryId + 1000);
+
+        DiaryEntity diary = TestUtil.makeDiaryEntityWithScope(owner, DiaryScope.PUBLIC);
+        ReflectionTestUtils.setField(diary, "id", diaryId);
+        ReflectionTestUtils.setField(diary, "createDateTime", LocalDateTime.now().minusDays(daysAgo));
+        ReflectionTestUtils.setField(diary, "updateDateTime", LocalDateTime.now().minusDays(daysAgo));
+
+        if (genre != null || artistId != null) {
+            diary.assignMusicMetadata(new MusicMetadataEntity(
+                    MusicMetadataSourceType.ITUNES,
+                    "track-" + diaryId,
+                    artistId,
+                    genre
+            ));
+        }
+
+        return diary;
+    }
+}

--- a/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/apptive/team5/recommendation/service/RecommendationServiceTest.java
@@ -44,9 +44,11 @@ class RecommendationServiceTest {
     private UserGenrePreferenceLowService userGenrePreferenceLowService;
     @Mock
     private UserArtistPreferenceLowService userArtistPreferenceLowService;
+    @Mock
+    private ExploreExposureService exploreExposureService;
 
     @Test
-    @DisplayName("선호도 일치 다이어리 우선 조회")
+    @DisplayName("returns personalized results first")
     void getExploreRecommendations_returnsPersonalizedResultsFirst() {
         Long userId = 1L;
         DiaryEntity matched = createDiary(101L, "K-Pop", "artist-1", 1);
@@ -65,6 +67,7 @@ class RecommendationServiceTest {
                 .willReturn(Set.of());
         given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(101L, 102L, 103L)))
                 .willReturn(java.util.Map.of(101L, 5L, 102L, 1L, 103L, 10L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of());
 
         List<RecommendationService.RecommendedDiaryResult> result =
                 recommendationService.getExploreRecommendations(userId, Set.of(userId));
@@ -77,7 +80,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("선호도 없으면 인기순 탐색 결과 반환")
+    @DisplayName("returns cold start results")
     void getExploreRecommendations_returnsColdStartResults() {
         Long userId = 1L;
         DiaryEntity popular = createDiary(201L, null, null, 1);
@@ -91,6 +94,7 @@ class RecommendationServiceTest {
         given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(201L, 202L))).willReturn(Set.of());
         given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(201L, 202L)))
                 .willReturn(java.util.Map.of(201L, 10L, 202L, 1L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of());
 
         List<RecommendationService.RecommendedDiaryResult> result =
                 recommendationService.getExploreRecommendations(userId, Set.of(userId));
@@ -102,7 +106,7 @@ class RecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("매칭 다이어리 없으면 랜덤 탐색 결과 반환")
+    @DisplayName("returns fallback random when there is no match")
     void getExploreRecommendations_returnsFallbackRandomWhenNoMatch() {
         Long userId = 1L;
         DiaryEntity first = createDiary(301L, "Rock", "artist-2", 1);
@@ -118,6 +122,7 @@ class RecommendationServiceTest {
         given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(301L, 302L))).willReturn(Set.of());
         given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(301L, 302L)))
                 .willReturn(java.util.Map.of(301L, 2L, 302L, 3L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of());
 
         List<RecommendationService.RecommendedDiaryResult> result =
                 recommendationService.getExploreRecommendations(userId, Set.of(userId));
@@ -125,6 +130,60 @@ class RecommendationServiceTest {
         assertThat(result).isNotEmpty();
         assertThat(result).allMatch(recommendedDiaryResult -> !recommendedDiaryResult.recommended());
         assertThat(result).allMatch(recommendedDiaryResult -> "FALLBACK_RANDOM".equals(recommendedDiaryResult.reason()));
+    }
+
+    @Test
+    @DisplayName("excludes recent exposures first")
+    void getExploreRecommendations_excludesRecentlyExposedDiariesFirst() {
+        Long userId = 1L;
+        DiaryEntity recentExposed = createDiary(401L, "K-Pop", "artist-1", 1);
+        DiaryEntity nextCandidate = createDiary(402L, "K-Pop", "artist-1", 2);
+        DiaryEntity fallbackCandidate = createDiary(403L, "Rock", "artist-2", 3);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(recentExposed, nextCandidate, fallbackCandidate));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(401L, 402L, 403L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(401L, 402L, 403L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(401L, 402L, 403L)))
+                .willReturn(java.util.Map.of(401L, 5L, 402L, 4L, 403L, 1L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of(401L));
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result.getFirst().diary().getId()).isEqualTo(402L);
+        assertThat(result).extracting(r -> r.diary().getId()).contains(403L);
+    }
+
+    @Test
+    @DisplayName("relaxes recent exposure filtering when candidates are short")
+    void getExploreRecommendations_relaxesRecentExposureForFallback() {
+        Long userId = 1L;
+        DiaryEntity first = createDiary(501L, "Rock", "artist-2", 1);
+        DiaryEntity second = createDiary(502L, "Jazz", "artist-3", 2);
+
+        given(diaryLowService.findRecentExploreCandidates(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of(first, second));
+        given(userGenrePreferenceLowService.findTop3ByUserId(userId))
+                .willReturn(List.of(new UserGenrePreferenceEntity(TestUtil.makeUserEntityWithId(), "K-Pop", 9)));
+        given(userArtistPreferenceLowService.findTop5ByUserId(userId))
+                .willReturn(List.of(new UserArtistPreferenceEntity(TestUtil.makeUserEntityWithId(), "artist-1", 4)));
+        given(diaryLikeLowService.findLikedDiaryIdsByUser(userId, List.of(501L, 502L))).willReturn(Set.of());
+        given(diaryStoreLowService.findStoredDiaryIdsByUser(userId, List.of(501L, 502L))).willReturn(Set.of());
+        given(diaryLikeLowService.findLikeCountsByDiaryIds(List.of(501L, 502L)))
+                .willReturn(java.util.Map.of(501L, 2L, 502L, 3L));
+        given(exploreExposureService.findRecentlyExposedDiaryIds(userId)).willReturn(Set.of(501L, 502L));
+
+        List<RecommendationService.RecommendedDiaryResult> result =
+                recommendationService.getExploreRecommendations(userId, Set.of(userId));
+
+        assertThat(result).isNotEmpty();
+        assertThat(result).allMatch(recommendedDiaryResult -> "FALLBACK_RANDOM".equals(recommendedDiaryResult.reason()));
+        assertThat(result).extracting(r -> r.diary().getId()).containsExactlyInAnyOrder(501L, 502L);
     }
 
     private DiaryEntity createDiary(Long diaryId, String genre, String artistId, int daysAgo) {

--- a/src/test/java/apptive/team5/util/TestUtil.java
+++ b/src/test/java/apptive/team5/util/TestUtil.java
@@ -122,7 +122,8 @@ public final class TestUtil {
                 "30S",
                 "PT2M58S",
                 "PT1M1S",
-                "PT1M31S"
+                "PT1M31S",
+                null
         );
     }
 
@@ -137,7 +138,8 @@ public final class TestUtil {
                 "30S",
                 "PT2M58S",
                 "PT1M1S",
-                "PT1M31S"
+                "PT1M31S",
+                null
         );
     }
 }

--- a/src/test/java/apptive/team5/util/TestUtil.java
+++ b/src/test/java/apptive/team5/util/TestUtil.java
@@ -106,7 +106,8 @@ public final class TestUtil {
                 "PT2M58S",
                 "PT1M1S",
                 "PT1M31S",
-                user
+                user,
+                null
         );
     }
 


### PR DESCRIPTION
# 변경점 👍
탐색 탭 GET /api/diaries/randoms에 추천 로직 반영
추천을 위해 ITunes api 필드 4개 사용 (optional)
- sourceType
- trackId
- artistId
- primaryGenreName
 
메타 데이터 관리 테이블 추가 
- music_metadata
- user_genre_preference
- user_artist_preference

조회한 킬링파트 제외 다른 킬링파트 조회 유도
추천 후보 부족할 시 단계별로 제약 제거해서 최종적으로 추천할 자료 없어도 적어도 기존처럼 탐색할 수 있도록 구성
